### PR TITLE
Issue #4: Display the IT request category list

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,7 +6,6 @@ type UiState = "idle" | "loading" | "success" | "error";
 export default function App() {
   const [state, setState] = useState<UiState>("idle");
   const [categories, setCategories] = useState<Category[]>([]);
-  void categories;
 
   async function handleCheck() {
     setState("loading");
@@ -14,7 +13,7 @@ export default function App() {
     try {
       const result = await checkSystem();
       setCategories(result.categories);
-      setState(result.online ? "success" : "error");
+      setState("success");
     } catch {
       setCategories([]);
       setState("error");
@@ -36,9 +35,23 @@ export default function App() {
       </button>
 
       {state === "success" && (
-        <div className="alert alert-success mt-4">
-          <strong>System Status:</strong> Online
-        </div>
+        <>
+          <div className="alert alert-success mt-4">
+            <strong>System Status:</strong> Online
+          </div>
+
+          <section className="mt-4">
+            <h2 className="h5">IT Request Categories</h2>
+
+            <ul className="list-group">
+              {categories.map((category) => (
+                <li className="list-group-item" key={category.id}>
+                  {category.name}
+                </li>
+              ))}
+            </ul>
+          </section>
+        </>
       )}
 
       {state === "error" && (

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -10,19 +10,14 @@ export interface SystemStatus {
   categories: Category[];
 }
 
-// Issue 2 + Issue 4 — call the backend.
-// Steps: fetch `${API_URL}/api/health`; if not ok, throw.
-//        then fetch `${API_URL}/api/categories`; if not ok, throw.
-//        return { online: true, categories }.
-// Throwing on failure lets the UI show a single Offline/error state.
 export async function checkSystem(): Promise<SystemStatus> {
-  const response = await fetch(`${API_URL}/api/health`);
+  const healthResponse = await fetch(`${API_URL}/api/health`);
 
-  if (!response.ok) {
+  if (!healthResponse.ok) {
     throw new Error("Unable to connect to TokTickIT API");
   }
 
-  const health = (await response.json()) as {
+  const health = (await healthResponse.json()) as {
     status: string;
     service: string;
   };
@@ -31,8 +26,16 @@ export async function checkSystem(): Promise<SystemStatus> {
     throw new Error("TokTickIT API returned an invalid response");
   }
 
+  const categoriesResponse = await fetch(`${API_URL}/api/categories`);
+
+  if (!categoriesResponse.ok) {
+    throw new Error("Unable to load IT request categories");
+  }
+
+  const categories = (await categoriesResponse.json()) as Category[];
+
   return {
     online: true,
-    categories: [],
+    categories,
   };
 }

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -1,17 +1,55 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
 import App from "../../src/App.js";
+import * as api from "../../src/api.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("App", () => {
-  // WORKED EXAMPLE — provided for you.
   it("renders the TokTickIT heading", () => {
     render(<App />);
+
     expect(screen.getByText(/TokTickIT/i)).toBeInTheDocument();
   });
 
-  // Issue 4 — write these yourself. Hint: mock the api module with
-  // vi.spyOn(api, "checkSystem").mockResolvedValue(...) / .mockRejectedValue(...)
-  // then click the button and assert the Online list / Offline message.
-  it.todo("shows Online and the seeded categories on success");
-  it.todo("shows an Offline error message when the API is unavailable");
+  it("shows Online and the seeded categories on success", async () => {
+    vi.spyOn(api, "checkSystem").mockResolvedValue({
+      online: true,
+      categories: [
+        { id: 1, name: "Account and Access" },
+        { id: 2, name: "Hardware" },
+        { id: 3, name: "Software" },
+        { id: 4, name: "Network" },
+      ],
+    });
+
+    render(<App />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Check System" }),
+    );
+
+    expect(await screen.findByText(/Online/i)).toBeInTheDocument();
+    expect(screen.getByText("Account and Access")).toBeInTheDocument();
+    expect(screen.getByText("Hardware")).toBeInTheDocument();
+    expect(screen.getByText("Software")).toBeInTheDocument();
+    expect(screen.getByText("Network")).toBeInTheDocument();
+  });
+
+  it("shows an Offline error message when the API is unavailable", async () => {
+    vi.spyOn(api, "checkSystem").mockRejectedValue(
+      new Error("API unavailable"),
+    );
+
+    render(<App />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Check System" }),
+    );
+
+    expect(await screen.findByText(/Offline/i)).toBeInTheDocument();
+    expect(
+      screen.getByText("Unable to connect to TokTickIT API"),
+    ).toBeInTheDocument();
+  });
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,37 +1,37 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
 import { getPrisma } from "./prisma.js";
-// getPrisma() is your lazy database handle. Call it INSIDE a route when you
-// need the DB (Issue 4). It is intentionally unused until then.
-void getPrisma;
 
-// The Express app is exported separately from app.listen() (see index.ts) so
-// Supertest can import `app` without opening a port. Do not merge these files.
 export const app = express();
 
-app.use(cors());          // already wired: lets the Vite dev server call this API
+app.use(cors());
 app.use(express.json());
 
-// ---------------------------------------------------------------------------
-// Issue 2 — API health check
-// Make the test in tests/lab-01/health.test.ts pass.
-// It must return HTTP 200 with JSON: { status: "ok", service: "TokTickIT API" }
-// ---------------------------------------------------------------------------
 app.get("/api/health", (_req: Request, res: Response) => {
-  // TODO(Issue 2): replace this stub with the required 200 response.
   res.status(200).json({
-    status: "ok" ,
-    service: "TokTickIT API" ,
-   });
+    status: "ok",
+    service: "TokTickIT API",
+  });
 });
 
-// ---------------------------------------------------------------------------
-// Issue 4 — Category list
-// Add:  GET /api/categories
-//   -> read categories from PostgreSQL via getPrisma().category.findMany(...)
-//   -> return each { id, name } in a predictable (id) order
-//   -> on failure, respond 500 with a safe message (no internal details)
-// TODO(Issue 4): implement the route here.
-// ---------------------------------------------------------------------------
+app.get("/api/categories", async (_req: Request, res: Response) => {
+  try {
+    const categories = await getPrisma().category.findMany({
+      select: {
+        id: true,
+        name: true,
+      },
+      orderBy: {
+        id: "asc",
+      },
+    });
+
+    res.status(200).json(categories);
+  } catch {
+    res.status(500).json({
+      error: "Unable to load categories",
+    });
+  }
+});
 
 export default app;

--- a/server/tests/lab-01/categories.test.ts
+++ b/server/tests/lab-01/categories.test.ts
@@ -1,15 +1,20 @@
 import { describe, it, expect } from "vitest";
 import request from "supertest";
 import { app } from "../../src/app.js";
-void request; void app;
 
-// Issue 4 — write this test yourself, using health.test.ts as the pattern.
-// Requires the DB to be migrated and seeded first.
-// It should assert: GET /api/categories returns 200 and the four seeded
-// category names in id order.
-describe.todo("GET /api/categories", () => {
-  it.todo("returns the four seeded categories in id order", async () => {
-    // TODO(Issue 4): implement this assertion.
-    expect(true).toBe(true);
+describe("GET /api/categories", () => {
+  it("returns the four seeded categories in id order", async () => {
+    const res = await request(app).get("/api/categories");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { id: expect.any(Number), name: "Account and Access" },
+      { id: expect.any(Number), name: "Hardware" },
+      { id: expect.any(Number), name: "Software" },
+      { id: expect.any(Number), name: "Network" },
+    ]);
+
+    const ids = res.body.map((category: { id: number }) => category.id);
+    expect(ids).toEqual([...ids].sort((a, b) => a - b));
   });
 });


### PR DESCRIPTION
## Related Issue

Closes #4

## Summary

- Added GET /api/categories using Prisma.
- Returned category IDs and names in ascending ID order.
- Added safe error handling for database failures.
- Updated the frontend to request categories from the API.
- Added loading, Online, and Offline states.
- Displayed the four IT request categories using Bootstrap.
- Added Supertest and Vitest coverage.

## Verification

- Backend tests pass: 2 tests.
- Frontend tests pass: 3 tests.
- The application displays all four categories in the expected order.
- The application displays an Offline error when the API is unavailable.