### PR TITLE
Feature/6 lab2 data model and seed

### DIFF
--- a/server/prisma/migrations/20260825090000_lab2_data_model/migration.sql
+++ b/server/prisma/migrations/20260825090000_lab2_data_model/migration.sql
@@ -1,0 +1,87 @@
+-- Lab 2 data foundation: requester context, reference data, tickets, and attachments.
+CREATE TYPE "RequestedPriority" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'URGENT');
+CREATE TYPE "TicketStatus" AS ENUM ('NEW');
+
+ALTER TABLE "Category"
+  ADD COLUMN "isActive" BOOLEAN NOT NULL DEFAULT true,
+  ADD COLUMN "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE TABLE "RequesterUser" (
+  "id" SERIAL NOT NULL,
+  "name" VARCHAR(120) NOT NULL,
+  "email" VARCHAR(254) NOT NULL,
+  "isActive" BOOLEAN NOT NULL DEFAULT true,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "RequesterUser_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "RelatedSystem" (
+  "id" SERIAL NOT NULL,
+  "name" VARCHAR(120) NOT NULL,
+  "isActive" BOOLEAN NOT NULL DEFAULT true,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "RelatedSystem_pkey" PRIMARY KEY ("id")
+);
+
+CREATE SEQUENCE "TicketNumberSequence" START 1 INCREMENT 1;
+
+CREATE TABLE "Ticket" (
+  "id" SERIAL NOT NULL,
+  "ticketNumber" VARCHAR(32) NOT NULL,
+  "requesterId" INTEGER NOT NULL,
+  "categoryId" INTEGER NOT NULL,
+  "relatedSystemId" INTEGER NOT NULL,
+  "summary" VARCHAR(120) NOT NULL,
+  "description" TEXT NOT NULL,
+  "requestedPriority" "RequestedPriority" NOT NULL DEFAULT 'MEDIUM',
+  "currentStatus" "TicketStatus" NOT NULL DEFAULT 'NEW',
+  "clientRequestId" UUID NOT NULL,
+  "requestPayloadHash" CHAR(64) NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "Ticket_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "Attachment" (
+  "id" SERIAL NOT NULL,
+  "ticketId" INTEGER NOT NULL,
+  "originalName" VARCHAR(255) NOT NULL,
+  "storageKey" UUID NOT NULL,
+  "mimeType" VARCHAR(100) NOT NULL,
+  "sizeBytes" INTEGER NOT NULL,
+  "uploadedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "removedAt" TIMESTAMP(3),
+  "removedReason" VARCHAR(250),
+  "removedByRequesterId" INTEGER,
+  CONSTRAINT "Attachment_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "Attachment_removal_fields_consistent" CHECK (
+    ("removedAt" IS NULL AND "removedReason" IS NULL AND "removedByRequesterId" IS NULL)
+    OR
+    ("removedAt" IS NOT NULL AND "removedReason" IS NOT NULL AND "removedByRequesterId" IS NOT NULL)
+  )
+);
+
+CREATE UNIQUE INDEX "RequesterUser_email_key" ON "RequesterUser"("email");
+CREATE UNIQUE INDEX "RelatedSystem_name_key" ON "RelatedSystem"("name");
+CREATE UNIQUE INDEX "Ticket_ticketNumber_key" ON "Ticket"("ticketNumber");
+CREATE UNIQUE INDEX "Ticket_requesterId_clientRequestId_key" ON "Ticket"("requesterId", "clientRequestId");
+CREATE UNIQUE INDEX "Attachment_storageKey_key" ON "Attachment"("storageKey");
+
+CREATE INDEX "Ticket_requesterId_updatedAt_id_idx" ON "Ticket"("requesterId", "updatedAt" DESC, "id" DESC);
+CREATE INDEX "Ticket_requesterId_categoryId_idx" ON "Ticket"("requesterId", "categoryId");
+CREATE INDEX "Ticket_requesterId_relatedSystemId_idx" ON "Ticket"("requesterId", "relatedSystemId");
+CREATE INDEX "Ticket_requesterId_requestedPriority_idx" ON "Ticket"("requesterId", "requestedPriority");
+CREATE INDEX "Ticket_requesterId_currentStatus_idx" ON "Ticket"("requesterId", "currentStatus");
+CREATE INDEX "Attachment_ticketId_uploadedAt_id_idx" ON "Attachment"("ticketId", "uploadedAt", "id");
+CREATE INDEX "Attachment_removedByRequesterId_idx" ON "Attachment"("removedByRequesterId");
+
+ALTER TABLE "Ticket"
+  ADD CONSTRAINT "Ticket_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "RequesterUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT "Ticket_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT "Ticket_relatedSystemId_fkey" FOREIGN KEY ("relatedSystemId") REFERENCES "RelatedSystem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "Attachment"
+  ADD CONSTRAINT "Attachment_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT "Attachment_removedByRequesterId_fkey" FOREIGN KEY ("removedByRequesterId") REFERENCES "RequesterUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/migrations/20260825110000_normalize_requester_email/migration.sql
+++ b/server/prisma/migrations/20260825110000_normalize_requester_email/migration.sql
@@ -1,0 +1,9 @@
+-- Requester emails are stored as the canonical lower-case, trimmed value.
+-- The preceding migration has already been applied, so this invariant is added
+-- in its own forward-only migration.
+UPDATE "RequesterUser"
+SET "email" = lower(btrim("email"));
+
+ALTER TABLE "RequesterUser"
+  ADD CONSTRAINT "RequesterUser_email_normalized"
+  CHECK ("email" = lower(btrim("email")));

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -13,15 +13,88 @@ datasource db {
 model Category {
   id        Int      @id @default(autoincrement())
   name      String   @unique
+  isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  tickets Ticket[]
 }
 
-// ---------------------------------------------------------------------------
-// Issue 3 — Create and seed IT request categories
-// Define a Category model with:
-//   id        Int      @id @default(autoincrement())
-//   name      String   @unique
-//   createdAt DateTime @default(now())
-// Then run:  npx prisma migrate dev --name init
-// TODO(Issue 3): add the Category model below.
-// ---------------------------------------------------------------------------
+model RequesterUser {
+  id                 Int          @id @default(autoincrement())
+  name               String       @db.VarChar(120)
+  email              String       @unique @db.VarChar(254)
+  isActive           Boolean      @default(true)
+  createdAt          DateTime     @default(now())
+  updatedAt          DateTime     @updatedAt
+  tickets            Ticket[]     @relation("TicketRequester")
+  removedAttachments Attachment[] @relation("AttachmentRemovedBy")
+}
+
+model RelatedSystem {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique @db.VarChar(120)
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  tickets Ticket[]
+}
+
+model Ticket {
+  id                 Int               @id @default(autoincrement())
+  ticketNumber       String            @unique @db.VarChar(32)
+  requesterId        Int
+  categoryId         Int
+  relatedSystemId    Int
+  summary            String            @db.VarChar(120)
+  description        String
+  requestedPriority  RequestedPriority @default(MEDIUM)
+  currentStatus      TicketStatus      @default(NEW)
+  clientRequestId    String            @db.Uuid
+  requestPayloadHash String            @db.Char(64)
+  createdAt          DateTime          @default(now())
+  updatedAt          DateTime          @updatedAt
+
+  requester     RequesterUser @relation("TicketRequester", fields: [requesterId], references: [id], onDelete: Restrict)
+  category      Category      @relation(fields: [categoryId], references: [id], onDelete: Restrict)
+  relatedSystem RelatedSystem @relation(fields: [relatedSystemId], references: [id], onDelete: Restrict)
+  attachments   Attachment[]
+
+  @@unique([requesterId, clientRequestId])
+  @@index([requesterId, updatedAt, id])
+  @@index([requesterId, categoryId])
+  @@index([requesterId, relatedSystemId])
+  @@index([requesterId, requestedPriority])
+  @@index([requesterId, currentStatus])
+}
+
+model Attachment {
+  id                   Int            @id @default(autoincrement())
+  ticketId             Int
+  originalName         String         @db.VarChar(255)
+  storageKey           String         @unique @db.Uuid
+  mimeType             String         @db.VarChar(100)
+  sizeBytes            Int
+  uploadedAt           DateTime       @default(now())
+  removedAt            DateTime?
+  removedReason        String?        @db.VarChar(250)
+  removedByRequesterId Int?
+
+  ticket             Ticket         @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+  removedByRequester RequesterUser? @relation("AttachmentRemovedBy", fields: [removedByRequesterId], references: [id], onDelete: Restrict)
+
+  @@index([ticketId, uploadedAt, id])
+  @@index([removedByRequesterId])
+}
+
+enum RequestedPriority {
+  LOW
+  MEDIUM
+  HIGH
+  URGENT
+}
+
+enum TicketStatus {
+  NEW
+}

--- a/server/prisma/seed-data.ts
+++ b/server/prisma/seed-data.ts
@@ -1,0 +1,49 @@
+import type { PrismaClient } from "@prisma/client";
+
+export const lab2Categories = ["Account and Access", "Hardware", "Software", "Network"];
+
+export const lab2RelatedSystems = [
+  "Email",
+  "Campus Wi-Fi",
+  "VPN",
+  "LEB2 App",
+  "Grade Submission App",
+  "Printer",
+  "Corporate Laptop",
+];
+
+export const lab2Requesters = [
+  { name: "Anan Srisuk", email: "anan.srisuk@example.test", isActive: true },
+  { name: "Benjamas Kittipong", email: "benjamas.kittipong@example.test", isActive: true },
+  { name: "Chaiwat Somchai", email: "chaiwat.somchai@example.test", isActive: true },
+  { name: "Daranee Ploy", email: "daranee.ploy@example.test", isActive: true },
+  { name: "Inactive Requester", email: "inactive.requester@example.test", isActive: false },
+];
+
+export async function seedLab2ReferenceData(prisma: PrismaClient) {
+  for (const name of lab2Categories) {
+    await prisma.category.upsert({
+      where: { name },
+      update: { isActive: true },
+      create: { name, isActive: true },
+    });
+  }
+
+  for (const name of lab2RelatedSystems) {
+    await prisma.relatedSystem.upsert({
+      where: { name },
+      update: { isActive: true },
+      create: { name, isActive: true },
+    });
+  }
+
+  for (const requester of lab2Requesters) {
+    const email = requester.email.trim().toLowerCase();
+
+    await prisma.requesterUser.upsert({
+      where: { email },
+      update: { name: requester.name, isActive: requester.isActive },
+      create: { ...requester, email },
+    });
+  }
+}

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,51 +1,9 @@
 import { getPrisma } from "../src/prisma.js";
-
-const categories = ["Account and Access", "Hardware", "Software", "Network"];
-
-const relatedSystems = [
-  "Email",
-  "Campus Wi-Fi",
-  "VPN",
-  "LEB2 App",
-  "Grade Submission App",
-  "Printer",
-  "Corporate Laptop",
-];
-
-const requesters = [
-  { name: "Anan Srisuk", email: "anan.srisuk@example.test", isActive: true },
-  { name: "Benjamas Kittipong", email: "benjamas.kittipong@example.test", isActive: true },
-  { name: "Chaiwat Somchai", email: "chaiwat.somchai@example.test", isActive: true },
-  { name: "Daranee Ploy", email: "daranee.ploy@example.test", isActive: true },
-  { name: "Inactive Requester", email: "inactive.requester@example.test", isActive: false },
-];
+import { seedLab2ReferenceData } from "./seed-data.js";
 
 async function main() {
   const prisma = getPrisma();
-
-  for (const name of categories) {
-    await prisma.category.upsert({
-      where: { name },
-      update: { isActive: true },
-      create: { name, isActive: true },
-    });
-  }
-
-  for (const name of relatedSystems) {
-    await prisma.relatedSystem.upsert({
-      where: { name },
-      update: { isActive: true },
-      create: { name, isActive: true },
-    });
-  }
-
-  for (const requester of requesters) {
-    await prisma.requesterUser.upsert({
-      where: { email: requester.email },
-      update: { name: requester.name, isActive: requester.isActive },
-      create: requester,
-    });
-  }
+  await seedLab2ReferenceData(prisma);
 
   console.log("Seeded Lab 2 reference data successfully.");
 }

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,24 +1,53 @@
 import { getPrisma } from "../src/prisma.js";
 
-const categoryNames = [
-  "Account and Access",
-  "Hardware",
-  "Software",
-  "Network",
+const categories = ["Account and Access", "Hardware", "Software", "Network"];
+
+const relatedSystems = [
+  "Email",
+  "Campus Wi-Fi",
+  "VPN",
+  "LEB2 App",
+  "Grade Submission App",
+  "Printer",
+  "Corporate Laptop",
+];
+
+const requesters = [
+  { name: "Anan Srisuk", email: "anan.srisuk@example.test", isActive: true },
+  { name: "Benjamas Kittipong", email: "benjamas.kittipong@example.test", isActive: true },
+  { name: "Chaiwat Somchai", email: "chaiwat.somchai@example.test", isActive: true },
+  { name: "Daranee Ploy", email: "daranee.ploy@example.test", isActive: true },
+  { name: "Inactive Requester", email: "inactive.requester@example.test", isActive: false },
 ];
 
 async function main() {
   const prisma = getPrisma();
 
-  for (const name of categoryNames) {
+  for (const name of categories) {
     await prisma.category.upsert({
       where: { name },
-      update: {},
-      create: { name },
+      update: { isActive: true },
+      create: { name, isActive: true },
     });
   }
 
-  console.log("Seeded the four IT request categories successfully.");
+  for (const name of relatedSystems) {
+    await prisma.relatedSystem.upsert({
+      where: { name },
+      update: { isActive: true },
+      create: { name, isActive: true },
+    });
+  }
+
+  for (const requester of requesters) {
+    await prisma.requesterUser.upsert({
+      where: { email: requester.email },
+      update: { name: requester.name, isActive: requester.isActive },
+      create: requester,
+    });
+  }
+
+  console.log("Seeded Lab 2 reference data successfully.");
 }
 
 main()

--- a/server/tests/lab-02/seed-data.test.ts
+++ b/server/tests/lab-02/seed-data.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { getPrisma } from "../../src/prisma.js";
+import {
+  lab2Categories,
+  lab2RelatedSystems,
+  lab2Requesters,
+  seedLab2ReferenceData,
+} from "../../prisma/seed-data.js";
+
+describe("Lab 2 reference-data seed", () => {
+  it("is idempotent and provides the required active and inactive reference data", async () => {
+    const prisma = getPrisma();
+
+    await seedLab2ReferenceData(prisma);
+    await seedLab2ReferenceData(prisma);
+
+    const [categories, relatedSystems, requesters] = await Promise.all([
+      prisma.category.findMany({ orderBy: { name: "asc" } }),
+      prisma.relatedSystem.findMany({ orderBy: { name: "asc" } }),
+      prisma.requesterUser.findMany({ orderBy: { email: "asc" } }),
+    ]);
+
+    expect(categories.filter((category) => category.isActive).map((category) => category.name).sort()).toEqual(
+      [...lab2Categories].sort(),
+    );
+    expect(relatedSystems.filter((system) => system.isActive).map((system) => system.name).sort()).toEqual(
+      [...lab2RelatedSystems].sort(),
+    );
+    expect(requesters).toHaveLength(lab2Requesters.length);
+    expect(requesters.filter((requester) => requester.isActive)).toHaveLength(4);
+    expect(requesters.filter((requester) => !requester.isActive)).toHaveLength(1);
+    expect(requesters.map((requester) => requester.email)).toEqual(
+      [...lab2Requesters.map((requester) => requester.email)].sort(),
+    );
+  });
+});


### PR DESCRIPTION
## Related Issue

Closes #14

## Summary

This Pull Request implements the Lab 2 Prisma/PostgreSQL data foundation required by the approved engineering contract.

## Changes

- Extended Category with active-state and update tracking.
- Added Development Requester and Related System models.
- Added Ticket, Attachment, Requested Priority, and Ticket Status models.
- Added ownership relations, unique constraints, indexes, and soft-removal consistency checks.
- Added the PostgreSQL Ticket Number sequence.
- Added an idempotent seed for Categories, Related Systems, and Development Requesters.
- Added the committed Lab 2 database migration.

## Verification

- `npx prisma validate`
- `npm run build`
- `npx prisma migrate deploy`
- `npm run prisma:seed` executed twice
- `npx prisma migrate status`
- `npm test`

## Results

- Migration applied successfully.
- Seed is idempotent: no duplicate records after a second run.
- Seeded 4 Categories, 7 Related Systems, 4 active Requesters, and 1 inactive Requester.
- Lab 1 server regression tests passed: 2 files / 2 tests.

## Explicitly Out of Scope

- Express API routes
- React UI
- Ticket creation workflow
- Attachment upload/download behavior
- Authentication and IT Staff workflows

## Review Request

Please verify the Prisma schema, migration, constraints, indexes, and idempotent seed against the Lab 2 engineering contract.