### PR TITLE
Feature/7 lab2 requester context api

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,64 +1,73 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
+import type { PrismaClient } from "@prisma/client";
 import { getPrisma } from "./prisma.js";
 
-export const app = express();
+export type ReferenceDataPrisma = Pick<PrismaClient, "category" | "relatedSystem" | "requesterUser">;
 
-app.use(cors());
-app.use(express.json());
+export function createApp(prisma: ReferenceDataPrisma = getPrisma()): express.Express {
+  const app = express();
 
-app.get("/api/health", (_req: Request, res: Response) => {
-  res.status(200).json({
-    status: "ok",
-    service: "TokTickIT API",
+  app.use(cors());
+  app.use(express.json());
+
+  app.get("/api/health", (_req: Request, res: Response) => {
+    res.status(200).json({
+      status: "ok",
+      service: "TokTickIT API",
+    });
   });
-});
 
-app.get("/api/categories", async (_req: Request, res: Response) => {
-  try {
-    const categories = await getPrisma().category.findMany({
-      select: {
-        id: true,
-        name: true,
-      },
-      where: { isActive: true },
-      orderBy: {
-        id: "asc",
-      },
-    });
+  app.get("/api/categories", async (_req: Request, res: Response) => {
+    try {
+      const categories = await prisma.category.findMany({
+        select: {
+          id: true,
+          name: true,
+        },
+        where: { isActive: true },
+        orderBy: {
+          id: "asc",
+        },
+      });
 
-    res.status(200).json(categories);
-  } catch {
-    res.status(500).json({ error: "REFERENCE_DATA_UNAVAILABLE" });
-  }
-});
+      res.status(200).json(categories);
+    } catch {
+      res.status(500).json({ error: "REFERENCE_DATA_UNAVAILABLE" });
+    }
+  });
 
-app.get("/api/related-systems", async (_req: Request, res: Response) => {
-  try {
-    const relatedSystems = await getPrisma().relatedSystem.findMany({
-      where: { isActive: true },
-      select: { id: true, name: true },
-      orderBy: [{ name: "asc" }, { id: "asc" }],
-    });
+  app.get("/api/related-systems", async (_req: Request, res: Response) => {
+    try {
+      const relatedSystems = await prisma.relatedSystem.findMany({
+        where: { isActive: true },
+        select: { id: true, name: true },
+        orderBy: [{ name: "asc" }, { id: "asc" }],
+      });
 
-    res.status(200).json(relatedSystems);
-  } catch {
-    res.status(500).json({ error: "REFERENCE_DATA_UNAVAILABLE" });
-  }
-});
+      res.status(200).json(relatedSystems);
+    } catch {
+      res.status(500).json({ error: "REFERENCE_DATA_UNAVAILABLE" });
+    }
+  });
 
-app.get("/api/development-requesters", async (_req: Request, res: Response) => {
-  try {
-    const requesters = await getPrisma().requesterUser.findMany({
-      where: { isActive: true },
-      select: { id: true, name: true },
-      orderBy: [{ name: "asc" }, { id: "asc" }],
-    });
+  app.get("/api/development-requesters", async (_req: Request, res: Response) => {
+    try {
+      const requesters = await prisma.requesterUser.findMany({
+        where: { isActive: true },
+        select: { id: true, name: true },
+        orderBy: [{ name: "asc" }, { id: "asc" }],
+      });
 
-    res.status(200).json(requesters);
-  } catch {
-    res.status(500).json({ error: "REFERENCE_DATA_UNAVAILABLE" });
-  }
-});
+      res.status(200).json(requesters);
+    } catch {
+      res.status(500).json({ error: "REFERENCE_DATA_UNAVAILABLE" });
+    }
+  });
+
+  return app;
+}
+
+export const app = createApp();
 
 export default app;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -21,6 +21,7 @@ app.get("/api/categories", async (_req: Request, res: Response) => {
         id: true,
         name: true,
       },
+      where: { isActive: true },
       orderBy: {
         id: "asc",
       },
@@ -28,9 +29,35 @@ app.get("/api/categories", async (_req: Request, res: Response) => {
 
     res.status(200).json(categories);
   } catch {
-    res.status(500).json({
-      error: "Unable to load categories",
+    res.status(500).json({ error: "REFERENCE_DATA_UNAVAILABLE" });
+  }
+});
+
+app.get("/api/related-systems", async (_req: Request, res: Response) => {
+  try {
+    const relatedSystems = await getPrisma().relatedSystem.findMany({
+      where: { isActive: true },
+      select: { id: true, name: true },
+      orderBy: [{ name: "asc" }, { id: "asc" }],
     });
+
+    res.status(200).json(relatedSystems);
+  } catch {
+    res.status(500).json({ error: "REFERENCE_DATA_UNAVAILABLE" });
+  }
+});
+
+app.get("/api/development-requesters", async (_req: Request, res: Response) => {
+  try {
+    const requesters = await getPrisma().requesterUser.findMany({
+      where: { isActive: true },
+      select: { id: true, name: true },
+      orderBy: [{ name: "asc" }, { id: "asc" }],
+    });
+
+    res.status(200).json(requesters);
+  } catch {
+    res.status(500).json({ error: "REFERENCE_DATA_UNAVAILABLE" });
   }
 });
 

--- a/server/tests/lab-02/reference-data.api.test.ts
+++ b/server/tests/lab-02/reference-data.api.test.ts
@@ -1,6 +1,42 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import request from "supertest";
-import { app } from "../../src/app.js";
+import { app, createApp, type ReferenceDataPrisma } from "../../src/app.js";
+
+function makeReferenceDataPrisma(): ReferenceDataPrisma {
+  const categories = [
+    { id: 1, name: "Active Category", isActive: true },
+    { id: 2, name: "Inactive Category", isActive: false },
+  ];
+  const relatedSystems = [
+    { id: 1, name: "Active System", isActive: true },
+    { id: 2, name: "Inactive System", isActive: false },
+  ];
+  const requesters = [
+    { id: 1, name: "Active Requester", isActive: true },
+    { id: 2, name: "Inactive Requester", isActive: false },
+  ];
+
+  return {
+    category: {
+      findMany: vi.fn(async (args: { where?: { isActive?: boolean } }) =>
+        categories
+          .filter((item) => args.where?.isActive !== true || item.isActive)
+          .map(({ id, name }) => ({ id, name }))),
+    },
+    relatedSystem: {
+      findMany: vi.fn(async (args: { where?: { isActive?: boolean } }) =>
+        relatedSystems
+          .filter((item) => args.where?.isActive !== true || item.isActive)
+          .map(({ id, name }) => ({ id, name }))),
+    },
+    requesterUser: {
+      findMany: vi.fn(async (args: { where?: { isActive?: boolean } }) =>
+        requesters
+          .filter((item) => args.where?.isActive !== true || item.isActive)
+          .map(({ id, name }) => ({ id, name }))),
+    },
+  } as unknown as ReferenceDataPrisma;
+}
 
 describe("Lab 2 reference-data endpoints", () => {
   it("returns active categories in the existing Lab 1 id order", async () => {
@@ -40,5 +76,47 @@ describe("Lab 2 reference-data endpoints", () => {
       "Chaiwat Somchai",
       "Daranee Ploy",
     ]);
+  });
+
+  it("excludes inactive categories, systems, and requesters", async () => {
+    const prisma = makeReferenceDataPrisma();
+    const testApp = createApp(prisma);
+
+    const [categories, systems, requesters] = await Promise.all([
+      request(testApp).get("/api/categories"),
+      request(testApp).get("/api/related-systems"),
+      request(testApp).get("/api/development-requesters"),
+    ]);
+
+    expect(categories.body).toEqual([{ id: 1, name: "Active Category" }]);
+    expect(systems.body).toEqual([{ id: 1, name: "Active System" }]);
+    expect(requesters.body).toEqual([{ id: 1, name: "Active Requester" }]);
+    expect(prisma.category.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { isActive: true } }),
+    );
+    expect(prisma.relatedSystem.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { isActive: true } }),
+    );
+    expect(prisma.requesterUser.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { isActive: true } }),
+    );
+  });
+
+  it.each([
+    ["/api/categories", "category"],
+    ["/api/related-systems", "relatedSystem"],
+    ["/api/development-requesters", "requesterUser"],
+  ] as const)("returns a safe 500 when %s reference data fails", async (path, model) => {
+    const prisma = {
+      category: { findMany: vi.fn().mockRejectedValue(new Error("database unavailable")) },
+      relatedSystem: { findMany: vi.fn().mockRejectedValue(new Error("database unavailable")) },
+      requesterUser: { findMany: vi.fn().mockRejectedValue(new Error("database unavailable")) },
+    } as unknown as ReferenceDataPrisma;
+
+    const res = await request(createApp(prisma)).get(path);
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "REFERENCE_DATA_UNAVAILABLE" });
+    expect(prisma[model].findMany).toHaveBeenCalledOnce();
   });
 });

--- a/server/tests/lab-02/reference-data.api.test.ts
+++ b/server/tests/lab-02/reference-data.api.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+
+describe("Lab 2 reference-data endpoints", () => {
+  it("returns active categories in the existing Lab 1 id order", async () => {
+    const res = await request(app).get("/api/categories");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { id: expect.any(Number), name: "Account and Access" },
+      { id: expect.any(Number), name: "Hardware" },
+      { id: expect.any(Number), name: "Software" },
+      { id: expect.any(Number), name: "Network" },
+    ]);
+  });
+
+  it("returns active related systems ordered by name then id", async () => {
+    const res = await request(app).get("/api/related-systems");
+
+    expect(res.status).toBe(200);
+    expect(res.body.map((item: { name: string }) => item.name)).toEqual([
+      "Campus Wi-Fi",
+      "Corporate Laptop",
+      "Email",
+      "Grade Submission App",
+      "LEB2 App",
+      "Printer",
+      "VPN",
+    ]);
+  });
+
+  it("returns active development requesters only, ordered by name then id", async () => {
+    const res = await request(app).get("/api/development-requesters");
+
+    expect(res.status).toBe(200);
+    expect(res.body.map((item: { name: string }) => item.name)).toEqual([
+      "Anan Srisuk",
+      "Benjamas Kittipong",
+      "Chaiwat Somchai",
+      "Daranee Ploy",
+    ]);
+  });
+});


### PR DESCRIPTION
## Related Issue

Closes #16

## Summary

This Pull Request implements the Lab 2 public reference-data APIs required by the approved engineering contract.

## Changes

- Updated Categories endpoint to return active categories only
- Added Related Systems endpoint
- Added Development Requesters endpoint
- Added deterministic ordering
- Added reference-data API tests
- Added standard reference-data error responses

## Verification

- `npx prisma validate`
- `npm test`
- `npm run build`

All 6 tests pass.

## Out of Scope

- Ticket creation
- My Tickets
- Attachments
- UI
- Authentication