### PR TITLE
Lab 2: Implement Ticket creation API

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -1,0 +1,50 @@
+name: Server CI
+
+on:
+  pull_request:
+    branches: [main, lab2-staging]
+  push:
+    branches: [main, lab2-staging]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: toktickit
+          POSTGRES_PASSWORD: toktickit
+          POSTGRES_DB: toktickit
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U toktickit -d toktickit"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    defaults:
+      run:
+        working-directory: server
+    env:
+      DATABASE_URL: postgresql://toktickit:toktickit@localhost:5432/toktickit?schema=public
+      RUN_DB_INTEGRATION: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: server/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Apply migrations
+        run: npx prisma migrate deploy
+      - name: Seed reference data
+        run: npm run prisma:seed
+      - name: Run tests
+        run: npm test
+      - name: Build
+        run: npm run build

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -47,7 +47,8 @@ function errorResponse(
 function parseRequesterId(req: Request): number | null {
   const value = req.header("X-Requester-Id");
   if (!value || !/^[1-9]\d*$/.test(value)) return null;
-  return Number(value);
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
 function validateTicketBody(body: unknown): { input?: TicketCreateInput; fieldErrors: Record<string, string[]> } {
@@ -68,7 +69,7 @@ function validateTicketBody(body: unknown): { input?: TicketCreateInput; fieldEr
 
   for (const field of ["categoryId", "relatedSystemId"] as const) {
     const value = raw[field];
-    if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
       fieldErrors[field] = ["Must be a positive integer."];
     }
   }
@@ -128,6 +129,13 @@ function ticketResponse(ticket: {
     createdAt: ticket.createdAt.toISOString(),
     updatedAt: ticket.updatedAt.toISOString(),
   };
+}
+
+function isIdempotencyUniqueViolation(error: unknown): error is Prisma.PrismaClientKnownRequestError {
+  if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== "P2002") return false;
+  const target = error.meta?.target;
+  const fields = Array.isArray(target) ? target.map(String) : typeof target === "string" ? [target] : [];
+  return fields.includes("requesterId") && fields.includes("clientRequestId");
 }
 
 export function createApp(prisma: ReferenceDataPrisma = getPrisma()): express.Express {
@@ -272,7 +280,7 @@ export function createApp(prisma: ReferenceDataPrisma = getPrisma()): express.Ex
         const parsed = JSON.parse(error.message.slice("VALIDATION_FAILED:".length)) as Record<string, string[]>;
         return errorResponse(res, 400, "VALIDATION_FAILED", "Please correct the highlighted fields.", parsed);
       }
-      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      if (isIdempotencyUniqueViolation(error)) {
         try {
           const existing = await prisma.ticket.findUnique({
             where: { requesterId_clientRequestId: { requesterId, clientRequestId: input.clientRequestId } },

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,9 +1,134 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
-import type { PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient, type RequestedPriority } from "@prisma/client";
+import { createHash, randomUUID } from "node:crypto";
 import { getPrisma } from "./prisma.js";
 
-export type ReferenceDataPrisma = Pick<PrismaClient, "category" | "relatedSystem" | "requesterUser">;
+export type ReferenceDataPrisma = Pick<
+  PrismaClient,
+  "category" | "relatedSystem" | "requesterUser" | "ticket" | "$transaction" | "$queryRaw"
+>;
+
+const requestedPriorities = ["LOW", "MEDIUM", "HIGH", "URGENT"] as const;
+const ticketBodyFields = new Set([
+  "clientRequestId",
+  "categoryId",
+  "relatedSystemId",
+  "summary",
+  "requestedPriority",
+  "description",
+]);
+
+type TicketCreateInput = {
+  clientRequestId: string;
+  categoryId: number;
+  relatedSystemId: number;
+  summary: string;
+  requestedPriority: RequestedPriority;
+  description: string;
+};
+
+function errorResponse(
+  res: Response,
+  status: number,
+  code: string,
+  message: string,
+  fieldErrors?: Record<string, string[]>,
+) {
+  const error: { code: string; message: string; fieldErrors?: Record<string, string[]>; correlationId?: string } = {
+    code,
+    message,
+  };
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) error.fieldErrors = fieldErrors;
+  if (status >= 500) error.correlationId = randomUUID();
+  return res.status(status).json({ error });
+}
+
+function parseRequesterId(req: Request): number | null {
+  const value = req.header("X-Requester-Id");
+  if (!value || !/^[1-9]\d*$/.test(value)) return null;
+  return Number(value);
+}
+
+function validateTicketBody(body: unknown): { input?: TicketCreateInput; fieldErrors: Record<string, string[]> } {
+  const fieldErrors: Record<string, string[]> = {};
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { fieldErrors: { body: ["Request body must be a JSON object."] } };
+  }
+
+  const raw = body as Record<string, unknown>;
+  for (const key of Object.keys(raw)) {
+    if (!ticketBodyFields.has(key)) fieldErrors[key] = ["This field is not supported."];
+  }
+
+  const clientRequestId = raw.clientRequestId;
+  if (typeof clientRequestId !== "string" || !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(clientRequestId)) {
+    fieldErrors.clientRequestId = ["clientRequestId must be a valid UUID."];
+  }
+
+  for (const field of ["categoryId", "relatedSystemId"] as const) {
+    const value = raw[field];
+    if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+      fieldErrors[field] = ["Must be a positive integer."];
+    }
+  }
+
+  const summary = typeof raw.summary === "string" ? raw.summary.trim() : "";
+  if (summary.length < 5 || summary.length > 120) {
+    fieldErrors.summary = ["Summary must contain 5 to 120 characters."];
+  }
+
+  if (!requestedPriorities.includes(raw.requestedPriority as (typeof requestedPriorities)[number])) {
+    fieldErrors.requestedPriority = ["Requested priority is invalid."];
+  }
+
+  const description = typeof raw.description === "string" ? raw.description.trim() : "";
+  if (description.length < 10 || description.length > 5000) {
+    fieldErrors.description = ["Description must contain 10 to 5,000 characters."];
+  }
+
+  if (Object.keys(fieldErrors).length > 0) return { fieldErrors };
+  return {
+    fieldErrors,
+    input: {
+      clientRequestId: clientRequestId as string,
+      categoryId: raw.categoryId as number,
+      relatedSystemId: raw.relatedSystemId as number,
+      summary,
+      requestedPriority: raw.requestedPriority as RequestedPriority,
+      description,
+    },
+  };
+}
+
+function ticketResponse(ticket: {
+  id: number;
+  ticketNumber: string;
+  createdAt: Date;
+  updatedAt: Date;
+  summary: string;
+  description: string;
+  requestedPriority: RequestedPriority;
+  currentStatus: string;
+  requester: { id: number; name: string; email: string };
+  category: { id: number; name: string };
+  relatedSystem: { id: number; name: string };
+}) {
+  return {
+    id: ticket.id,
+    ticketNumber: ticket.ticketNumber,
+    ticketDate: ticket.createdAt.toISOString(),
+    requester: ticket.requester,
+    category: ticket.category,
+    relatedSystem: ticket.relatedSystem,
+    summary: ticket.summary,
+    requestedPriority: ticket.requestedPriority,
+    description: ticket.description,
+    currentStatus: ticket.currentStatus,
+    createdAt: ticket.createdAt.toISOString(),
+    updatedAt: ticket.updatedAt.toISOString(),
+  };
+}
 
 export function createApp(prisma: ReferenceDataPrisma = getPrisma()): express.Express {
   const app = express();
@@ -62,6 +187,92 @@ export function createApp(prisma: ReferenceDataPrisma = getPrisma()): express.Ex
       res.status(200).json(requesters);
     } catch {
       res.status(500).json({ error: "REFERENCE_DATA_UNAVAILABLE" });
+    }
+  });
+
+  app.post("/api/tickets", async (req: Request, res: Response) => {
+    const requesterId = parseRequesterId(req);
+    if (!requesterId) {
+      return errorResponse(res, 400, "REQUESTER_CONTEXT_INVALID", "A valid Development Requester is required.");
+    }
+
+    const { input, fieldErrors } = validateTicketBody(req.body);
+    if (!input) return errorResponse(res, 400, "VALIDATION_FAILED", "Please correct the highlighted fields.", fieldErrors);
+
+    const normalizedPayload = JSON.stringify({
+      categoryId: input.categoryId,
+      relatedSystemId: input.relatedSystemId,
+      summary: input.summary,
+      requestedPriority: input.requestedPriority,
+      description: input.description,
+    });
+    const requestPayloadHash = createHash("sha256").update(normalizedPayload).digest("hex");
+
+    try {
+      const ticket = await prisma.$transaction(async (tx) => {
+        const requester = await tx.requesterUser.findFirst({
+          where: { id: requesterId, isActive: true },
+          select: { id: true, name: true, email: true },
+        });
+        if (!requester) throw new Error("REQUESTER_CONTEXT_INVALID");
+
+        const [category, relatedSystem] = await Promise.all([
+          tx.category.findFirst({ where: { id: input.categoryId, isActive: true }, select: { id: true, name: true } }),
+          tx.relatedSystem.findFirst({ where: { id: input.relatedSystemId, isActive: true }, select: { id: true, name: true } }),
+        ]);
+        const referenceErrors: Record<string, string[]> = {};
+        if (!category) referenceErrors.categoryId = ["Category does not exist or is inactive."];
+        if (!relatedSystem) referenceErrors.relatedSystemId = ["Related System does not exist or is inactive."];
+        if (Object.keys(referenceErrors).length > 0) throw new Error(`VALIDATION_FAILED:${JSON.stringify(referenceErrors)}`);
+
+        const existing = await tx.ticket.findUnique({
+          where: { requesterId_clientRequestId: { requesterId, clientRequestId: input.clientRequestId } },
+          include: { requester: true, category: true, relatedSystem: true },
+        });
+        if (existing) {
+          if (existing.requestPayloadHash !== requestPayloadHash) throw new Error("IDEMPOTENCY_CONFLICT");
+          return { ticket: existing, replayed: true };
+        }
+
+        const [{ nextval }] = await tx.$queryRaw<Array<{ nextval: bigint }>>(
+          Prisma.sql`SELECT nextval('"TicketNumberSequence"')`,
+        );
+        const createdAt = new Date();
+        const ticketNumber = `TKT-${createdAt.getUTCFullYear()}-${nextval.toString().padStart(6, "0")}`;
+        const created = await tx.ticket.create({
+          data: {
+            ticketNumber,
+            requesterId,
+            categoryId: input.categoryId,
+            relatedSystemId: input.relatedSystemId,
+            summary: input.summary,
+            description: input.description,
+            requestedPriority: input.requestedPriority,
+            clientRequestId: input.clientRequestId,
+            requestPayloadHash,
+            createdAt,
+          },
+          include: { requester: true, category: true, relatedSystem: true },
+        });
+        return { ticket: created, replayed: false };
+      });
+
+      return res.status(ticket.replayed ? 200 : 201).json({
+        ticket: ticketResponse(ticket.ticket),
+        replayed: ticket.replayed,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message === "REQUESTER_CONTEXT_INVALID") {
+        return errorResponse(res, 400, "REQUESTER_CONTEXT_INVALID", "A valid Development Requester is required.");
+      }
+      if (error instanceof Error && error.message === "IDEMPOTENCY_CONFLICT") {
+        return errorResponse(res, 409, "IDEMPOTENCY_CONFLICT", "This request ID was already used for different ticket data.");
+      }
+      if (error instanceof Error && error.message.startsWith("VALIDATION_FAILED:")) {
+        const parsed = JSON.parse(error.message.slice("VALIDATION_FAILED:".length)) as Record<string, string[]>;
+        return errorResponse(res, 400, "VALIDATION_FAILED", "Please correct the highlighted fields.", parsed);
+      }
+      return errorResponse(res, 500, "TICKET_CREATE_FAILED", "Unable to create the Ticket.");
     }
   });
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -272,6 +272,22 @@ export function createApp(prisma: ReferenceDataPrisma = getPrisma()): express.Ex
         const parsed = JSON.parse(error.message.slice("VALIDATION_FAILED:".length)) as Record<string, string[]>;
         return errorResponse(res, 400, "VALIDATION_FAILED", "Please correct the highlighted fields.", parsed);
       }
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+        try {
+          const existing = await prisma.ticket.findUnique({
+            where: { requesterId_clientRequestId: { requesterId, clientRequestId: input.clientRequestId } },
+            include: { requester: true, category: true, relatedSystem: true },
+          });
+          if (existing) {
+            if (existing.requestPayloadHash !== requestPayloadHash) {
+              return errorResponse(res, 409, "IDEMPOTENCY_CONFLICT", "This request ID was already used for different ticket data.");
+            }
+            return res.status(200).json({ ticket: ticketResponse(existing), replayed: true });
+          }
+        } catch {
+          // Fall through to the safe generic error response.
+        }
+      }
       return errorResponse(res, 500, "TICKET_CREATE_FAILED", "Unable to create the Ticket.");
     }
   });

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -109,6 +109,83 @@ describe("POST /api/tickets", () => {
     });
   });
 
+  it.each(["0", "-1", "01", "1.0", "1abc", "1e2", "9007199254740992"])(
+    "rejects malformed or unsafe requester ID %s",
+    async (requesterId) => {
+      const { prisma } = makePrisma();
+      const res = await request(createApp(prisma))
+        .post("/api/tickets")
+        .set("X-Requester-Id", requesterId)
+        .send(validBody);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("REQUESTER_CONTEXT_INVALID");
+    },
+  );
+
+  it("rejects invalid UUID, unsafe reference IDs, whitespace-only text, and invalid priority", async () => {
+    const { prisma } = makePrisma();
+    const res = await request(createApp(prisma))
+      .post("/api/tickets")
+      .set("X-Requester-Id", "1")
+      .send({
+        ...validBody,
+        clientRequestId: "not-a-uuid",
+        categoryId: Number.MAX_SAFE_INTEGER + 1,
+        relatedSystemId: Number.MAX_SAFE_INTEGER + 1,
+        summary: "     ",
+        requestedPriority: "CRITICAL",
+        description: "          ",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.fieldErrors).toMatchObject({
+      clientRequestId: ["clientRequestId must be a valid UUID."],
+      categoryId: ["Must be a positive integer."],
+      relatedSystemId: ["Must be a positive integer."],
+      summary: ["Summary must contain 5 to 120 characters."],
+      requestedPriority: ["Requested priority is invalid."],
+      description: ["Description must contain 10 to 5,000 characters."],
+    });
+  });
+
+  it("accepts exact summary and description boundaries", async () => {
+    const { prisma, transaction } = makePrisma();
+    const body = {
+      ...validBody,
+      summary: "12345",
+      description: "1234567890",
+    };
+
+    const minimum = await request(createApp(prisma))
+      .post("/api/tickets")
+      .set("X-Requester-Id", "1")
+      .send(body);
+    expect(minimum.status).toBe(201);
+
+    const maximum = await request(createApp(makePrisma().prisma))
+      .post("/api/tickets")
+      .set("X-Requester-Id", "1")
+      .send({ ...body, clientRequestId: "6f0e0f5e-0f66-4a2e-89f8-6abacb67fd57", summary: "s".repeat(120), description: "d".repeat(5000) });
+    expect(maximum.status).toBe(201);
+    expect(transaction.ticket.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ summary: "12345", description: "1234567890" }),
+    }));
+  });
+
+  it("accepts URGENT priority", async () => {
+    const { prisma, transaction } = makePrisma();
+    const res = await request(createApp(prisma))
+      .post("/api/tickets")
+      .set("X-Requester-Id", "1")
+      .send({ ...validBody, requestedPriority: "URGENT" });
+
+    expect(res.status).toBe(201);
+    expect(transaction.ticket.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ requestedPriority: "URGENT" }),
+    }));
+  });
+
   it("rejects inactive or missing reference data", async () => {
     const { prisma, transaction } = makePrisma();
     transaction.category.findFirst.mockResolvedValue(null);
@@ -179,6 +256,7 @@ describe("POST /api/tickets", () => {
       new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
         code: "P2002",
         clientVersion: "5.22.0",
+        meta: { target: ["requesterId", "clientRequestId"] },
       }),
     );
 
@@ -190,6 +268,25 @@ describe("POST /api/tickets", () => {
     expect(res.status).toBe(200);
     expect(res.body.replayed).toBe(true);
     expect(res.body.ticket.ticketNumber).toBe(existing.ticketNumber);
+  });
+
+  it("does not treat a ticket number unique violation as an idempotency replay", async () => {
+    const { prisma, transaction } = makePrisma();
+    transaction.ticket.create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+        code: "P2002",
+        clientVersion: "5.22.0",
+        meta: { target: ["ticketNumber"] },
+      }),
+    );
+
+    const res = await request(createApp(prisma))
+      .post("/api/tickets")
+      .set("X-Requester-Id", "1")
+      .send(validBody);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("TICKET_CREATE_FAILED");
   });
 
   it("returns a safe 500 response when ticket creation fails", async () => {

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from "vitest";
+import request from "supertest";
+import { createHash } from "node:crypto";
+import { createApp, type ReferenceDataPrisma } from "../../src/app.js";
+
+const validBody = {
+  clientRequestId: "f13f2298-1153-4cea-966d-3bc466d53d7b",
+  categoryId: 2,
+  relatedSystemId: 7,
+  summary: "  Laptop battery drains quickly  ",
+  requestedPriority: "MEDIUM",
+  description: "  Battery drops from full to empty in about one hour.  ",
+};
+
+function makeTicket() {
+  const createdAt = new Date("2026-08-24T10:00:00.000Z");
+  return {
+    id: 42,
+    ticketNumber: "TKT-2026-000042",
+    requesterId: 1,
+    categoryId: 2,
+    relatedSystemId: 7,
+    summary: "Laptop battery drains quickly",
+    description: "Battery drops from full to empty in about one hour.",
+    requestedPriority: "MEDIUM" as const,
+    currentStatus: "NEW",
+    clientRequestId: validBody.clientRequestId,
+    requestPayloadHash: "hash",
+    createdAt,
+    updatedAt: createdAt,
+    requester: { id: 1, name: "Anan Srisuk", email: "anan.srisuk@example.test" },
+    category: { id: 2, name: "Hardware" },
+    relatedSystem: { id: 7, name: "Corporate Laptop" },
+  };
+}
+
+function makePrisma(options: { existing?: ReturnType<typeof makeTicket>; failTransaction?: boolean } = {}) {
+  const createdTicket = makeTicket();
+  const ticket = options.existing;
+  const transaction = {
+    requesterUser: {
+      findFirst: vi.fn().mockResolvedValue({ id: 1, name: "Anan Srisuk", email: "anan.srisuk@example.test" }),
+    },
+    category: {
+      findFirst: vi.fn().mockResolvedValue({ id: 2, name: "Hardware" }),
+    },
+    relatedSystem: {
+      findFirst: vi.fn().mockResolvedValue({ id: 7, name: "Corporate Laptop" }),
+    },
+    ticket: {
+      findUnique: vi.fn().mockResolvedValue(ticket),
+      create: vi.fn().mockResolvedValue(createdTicket),
+    },
+    $queryRaw: vi.fn().mockResolvedValue([{ nextval: 42n }]),
+  };
+  const prisma = {
+    ...transaction,
+    $transaction: vi.fn(async (callback: (tx: typeof transaction) => unknown) => {
+      if (options.failTransaction) throw new Error("database unavailable");
+      return callback(transaction);
+    }),
+  } as unknown as ReferenceDataPrisma;
+
+  return { prisma, transaction, createdTicket };
+}
+
+describe("POST /api/tickets", () => {
+  it("creates a Ticket with normalized text, server number, and NEW status", async () => {
+    const { prisma } = makePrisma();
+
+    const res = await request(createApp(prisma))
+      .post("/api/tickets")
+      .set("X-Requester-Id", "1")
+      .send(validBody);
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      replayed: false,
+      ticket: {
+        id: 42,
+        ticketNumber: "TKT-2026-000042",
+        ticketDate: "2026-08-24T10:00:00.000Z",
+        summary: "Laptop battery drains quickly",
+        description: "Battery drops from full to empty in about one hour.",
+        requestedPriority: "MEDIUM",
+        currentStatus: "NEW",
+      },
+    });
+  });
+
+  it("rejects missing requester context and invalid body fields", async () => {
+    const { prisma } = makePrisma();
+
+    const missingContext = await request(createApp(prisma)).post("/api/tickets").send(validBody);
+    expect(missingContext.status).toBe(400);
+    expect(missingContext.body.error.code).toBe("REQUESTER_CONTEXT_INVALID");
+
+    const invalidBody = await request(createApp(prisma))
+      .post("/api/tickets")
+      .set("X-Requester-Id", "1")
+      .send({ ...validBody, requesterId: 1, summary: "x", unknown: true });
+    expect(invalidBody.status).toBe(400);
+    expect(invalidBody.body.error.code).toBe("VALIDATION_FAILED");
+    expect(invalidBody.body.error.fieldErrors).toMatchObject({
+      requesterId: ["This field is not supported."],
+      unknown: ["This field is not supported."],
+      summary: ["Summary must contain 5 to 120 characters."],
+    });
+  });
+
+  it("rejects inactive or missing reference data", async () => {
+    const { prisma, transaction } = makePrisma();
+    transaction.category.findFirst.mockResolvedValue(null);
+
+    const res = await request(createApp(prisma))
+      .post("/api/tickets")
+      .set("X-Requester-Id", "1")
+      .send(validBody);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatchObject({
+      code: "VALIDATION_FAILED",
+      fieldErrors: { categoryId: ["Category does not exist or is inactive."] },
+    });
+  });
+
+  it("rejects an inactive requester context", async () => {
+    const { prisma, transaction } = makePrisma();
+    transaction.requesterUser.findFirst.mockResolvedValue(null);
+
+    const res = await request(createApp(prisma))
+      .post("/api/tickets")
+      .set("X-Requester-Id", "1")
+      .send(validBody);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("REQUESTER_CONTEXT_INVALID");
+  });
+
+  it("returns the existing Ticket on an idempotent replay", async () => {
+    const existing = makeTicket();
+    const { prisma, transaction } = makePrisma({ existing });
+    transaction.ticket.findUnique.mockResolvedValue({ ...existing, requestPayloadHash: hashFor(validBody) });
+
+    const res = await request(createApp(prisma))
+      .post("/api/tickets")
+      .set("X-Requester-Id", "1")
+      .send(validBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.replayed).toBe(true);
+    expect(res.body.ticket.ticketNumber).toBe(existing.ticketNumber);
+    expect(transaction.ticket.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects reuse of a request ID with a different payload", async () => {
+    const existing = makeTicket();
+    const { prisma, transaction } = makePrisma({ existing });
+    transaction.ticket.findUnique.mockResolvedValue({ ...existing, requestPayloadHash: "different-hash" });
+
+    const res = await request(createApp(prisma))
+      .post("/api/tickets")
+      .set("X-Requester-Id", "1")
+      .send(validBody);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("IDEMPOTENCY_CONFLICT");
+    expect(transaction.ticket.create).not.toHaveBeenCalled();
+  });
+
+  it("returns a safe 500 response when ticket creation fails", async () => {
+    const { prisma } = makePrisma({ failTransaction: true });
+
+    const res = await request(createApp(prisma))
+      .post("/api/tickets")
+      .set("X-Requester-Id", "1")
+      .send(validBody);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toMatchObject({
+      code: "TICKET_CREATE_FAILED",
+      message: "Unable to create the Ticket.",
+    });
+    expect(res.body.error.correlationId).toEqual(expect.any(String));
+  });
+});
+
+function hashFor(body: typeof validBody) {
+  const normalized = JSON.stringify({
+    categoryId: body.categoryId,
+    relatedSystemId: body.relatedSystemId,
+    summary: body.summary.trim(),
+    requestedPriority: body.requestedPriority,
+    description: body.description.trim(),
+  });
+  return createHash("sha256").update(normalized).digest("hex");
+}

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import request from "supertest";
 import { createHash } from "node:crypto";
+import { Prisma } from "@prisma/client";
 import { createApp, type ReferenceDataPrisma } from "../../src/app.js";
 
 const validBody = {
@@ -166,6 +167,29 @@ describe("POST /api/tickets", () => {
     expect(res.status).toBe(409);
     expect(res.body.error.code).toBe("IDEMPOTENCY_CONFLICT");
     expect(transaction.ticket.create).not.toHaveBeenCalled();
+  });
+
+  it("returns the existing Ticket when a concurrent create hits the unique constraint", async () => {
+    const existing = { ...makeTicket(), requestPayloadHash: hashFor(validBody) };
+    const { prisma, transaction } = makePrisma({ existing });
+    transaction.ticket.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(existing);
+    transaction.ticket.create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+        code: "P2002",
+        clientVersion: "5.22.0",
+      }),
+    );
+
+    const res = await request(createApp(prisma))
+      .post("/api/tickets")
+      .set("X-Requester-Id", "1")
+      .send(validBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.replayed).toBe(true);
+    expect(res.body.ticket.ticketNumber).toBe(existing.ticketNumber);
   });
 
   it("returns a safe 500 response when ticket creation fails", async () => {

--- a/server/tests/lab-02/create-ticket.postgres.integration.test.ts
+++ b/server/tests/lab-02/create-ticket.postgres.integration.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import request from "supertest";
+import { randomUUID } from "node:crypto";
+import { PrismaClient } from "@prisma/client";
+import { createApp } from "../../src/app.js";
+
+const runIntegration = process.env.RUN_DB_INTEGRATION === "1" && Boolean(process.env.DATABASE_URL);
+const integration = runIntegration ? describe : describe.skip;
+
+integration("POST /api/tickets PostgreSQL integration", () => {
+  let prisma: PrismaClient;
+  let requesterId: number;
+  let categoryId: number;
+  let relatedSystemId: number;
+  const requestIds: string[] = [];
+
+  beforeAll(async () => {
+    prisma = new PrismaClient();
+    await prisma.$connect();
+
+    const [requester, category, relatedSystem] = await Promise.all([
+      prisma.requesterUser.findFirst({ where: { isActive: true }, select: { id: true } }),
+      prisma.category.findFirst({ where: { isActive: true }, select: { id: true } }),
+      prisma.relatedSystem.findFirst({ where: { isActive: true }, select: { id: true } }),
+    ]);
+    if (!requester || !category || !relatedSystem) {
+      throw new Error("Integration test requires seeded active requester, category, and related system data.");
+    }
+    requesterId = requester.id;
+    categoryId = category.id;
+    relatedSystemId = relatedSystem.id;
+  });
+
+  afterAll(async () => {
+    if (!prisma) return;
+    if (requestIds.length > 0) {
+      await prisma.ticket.deleteMany({ where: { clientRequestId: { in: requestIds } } });
+    }
+    await prisma.$disconnect();
+  });
+
+  it("persists create, replays idempotently, rejects conflicts, and increments Ticket Numbers", async () => {
+    const app = createApp(prisma);
+    const firstRequestId = randomUUID();
+    const secondRequestId = randomUUID();
+    requestIds.push(firstRequestId, secondRequestId);
+    const firstBody = {
+      clientRequestId: firstRequestId,
+      categoryId,
+      relatedSystemId,
+      summary: "PostgreSQL integration ticket",
+      requestedPriority: "URGENT",
+      description: "Created against the real PostgreSQL database for Lab 2 verification.",
+    };
+
+    const first = await request(app).post("/api/tickets").set("X-Requester-Id", String(requesterId)).send(firstBody);
+    expect(first.status).toBe(201);
+    expect(first.body).toMatchObject({ replayed: false, ticket: { currentStatus: "NEW", requestedPriority: "URGENT" } });
+
+    const stored = await prisma.ticket.findUnique({
+      where: { requesterId_clientRequestId: { requesterId, clientRequestId: firstRequestId } },
+    });
+    expect(stored).toMatchObject({
+      requesterId,
+      categoryId,
+      relatedSystemId,
+      summary: firstBody.summary,
+      description: firstBody.description,
+      currentStatus: "NEW",
+      requestedPriority: "URGENT",
+    });
+
+    const replay = await request(app).post("/api/tickets").set("X-Requester-Id", String(requesterId)).send(firstBody);
+    expect(replay.status).toBe(200);
+    expect(replay.body).toMatchObject({ replayed: true, ticket: { ticketNumber: first.body.ticket.ticketNumber } });
+
+    const conflict = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(requesterId))
+      .send({ ...firstBody, summary: "A different ticket payload" });
+    expect(conflict.status).toBe(409);
+    expect(conflict.body.error.code).toBe("IDEMPOTENCY_CONFLICT");
+
+    const second = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(requesterId))
+      .send({ ...firstBody, clientRequestId: secondRequestId, summary: "Second PostgreSQL ticket" });
+    expect(second.status).toBe(201);
+
+    const firstNumber = /^TKT-\d{4}-(\d{6})$/.exec(first.body.ticket.ticketNumber);
+    const secondNumber = /^TKT-\d{4}-(\d{6})$/.exec(second.body.ticket.ticketNumber);
+    expect(firstNumber).not.toBeNull();
+    expect(secondNumber).not.toBeNull();
+    expect(Number(secondNumber![1])).toBeGreaterThan(Number(firstNumber![1]));
+    await expect(prisma.ticket.count({ where: { requesterId, clientRequestId: { in: requestIds } } })).resolves.toBe(2);
+  });
+});


### PR DESCRIPTION
## Related Issue

Closes #18

## Summary

This Pull Request implements the Lab 2 Ticket creation API required by the approved engineering contract.

## Changes

- Added `POST /api/tickets`
- Added requester context validation
- Added request and reference-data validation
- Added backend-generated Ticket Numbers
- Added `NEW` status
- Added atomic transaction behavior
- Added idempotency replay and conflict handling
- Added concurrent unique-constraint handling
- Added automated API tests

## Verification

- `npx prisma validate`
- `npm test`
- `npm run build`

All 18 tests pass.

## Out of Scope

- My Tickets
- Ticket detail
- Attachments
- UI
- Authentication