### PR TITLE
Lab 2: Add My Tickets API

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -28,6 +28,30 @@ type TicketCreateInput = {
   description: string;
 };
 
+type TicketListQuery = {
+  search: string;
+  categoryId: number | null;
+  relatedSystemId: number | null;
+  requestedPriority: RequestedPriority | null;
+  currentStatus: "NEW" | null;
+  sortBy: "createdAt" | "updatedAt" | "ticketNumber";
+  sortDirection: "asc" | "desc";
+  page: number;
+  pageSize: 10 | 20 | 50;
+};
+
+const ticketListQueryFields = new Set([
+  "search",
+  "categoryId",
+  "relatedSystemId",
+  "requestedPriority",
+  "currentStatus",
+  "sortBy",
+  "sortDirection",
+  "page",
+  "pageSize",
+]);
+
 function errorResponse(
   res: Response,
   status: number,
@@ -102,6 +126,113 @@ function validateTicketBody(body: unknown): { input?: TicketCreateInput; fieldEr
   };
 }
 
+function parseTicketListQuery(query: Request["query"]): { input?: TicketListQuery; fieldErrors: Record<string, string[]> } {
+  const fieldErrors: Record<string, string[]> = {};
+  const raw = query as Record<string, unknown>;
+  for (const key of Object.keys(raw)) {
+    if (!ticketListQueryFields.has(key)) fieldErrors[key] = ["This query parameter is not supported."];
+  }
+
+  const read = (field: string): string | undefined => {
+    const value = raw[field];
+    if (value === undefined) return undefined;
+    if (typeof value !== "string") {
+      fieldErrors[field] = ["This query parameter must be provided once."];
+      return undefined;
+    }
+    return value;
+  };
+
+  const searchValue = read("search");
+  const search = searchValue?.trim() ?? "";
+  if (search.length > 120) fieldErrors.search = ["Search must contain at most 120 characters."];
+
+  const parseId = (field: "categoryId" | "relatedSystemId"): number | null => {
+    const value = read(field);
+    if (value === undefined) return null;
+    if (!/^[1-9]\d*$/.test(value)) {
+      fieldErrors[field] = ["Must be a positive integer."];
+      return null;
+    }
+    const parsed = Number(value);
+    if (!Number.isSafeInteger(parsed)) {
+      fieldErrors[field] = ["Must be a safe positive integer."];
+      return null;
+    }
+    return parsed;
+  };
+
+  const categoryId = parseId("categoryId");
+  const relatedSystemId = parseId("relatedSystemId");
+  const priorityValue = read("requestedPriority");
+  const requestedPriority = priorityValue === undefined ? null : requestedPriorities.includes(priorityValue as (typeof requestedPriorities)[number])
+    ? (priorityValue as RequestedPriority)
+    : null;
+  if (priorityValue !== undefined && requestedPriority === null) {
+    fieldErrors.requestedPriority = ["Requested priority is invalid."];
+  }
+
+  const statusValue = read("currentStatus");
+  const currentStatus = statusValue === undefined ? null : statusValue === "NEW" ? "NEW" : null;
+  if (statusValue !== undefined && currentStatus === null) fieldErrors.currentStatus = ["Current status is invalid."];
+
+  const sortByValue = read("sortBy");
+  const sortBy = sortByValue === undefined ? "updatedAt" : ["createdAt", "updatedAt", "ticketNumber"].includes(sortByValue)
+    ? (sortByValue as TicketListQuery["sortBy"])
+    : null;
+  if (sortByValue !== undefined && sortBy === null) fieldErrors.sortBy = ["Sort field is invalid."];
+
+  const sortDirectionValue = read("sortDirection");
+  const sortDirection = sortDirectionValue === undefined ? "desc" : ["asc", "desc"].includes(sortDirectionValue)
+    ? (sortDirectionValue as TicketListQuery["sortDirection"])
+    : null;
+  if (sortDirectionValue !== undefined && sortDirection === null) fieldErrors.sortDirection = ["Sort direction is invalid."];
+
+  const parsePage = (): number => {
+    const value = read("page");
+    if (value === undefined) return 1;
+    if (!/^[1-9]\d*$/.test(value)) {
+      fieldErrors.page = ["Page must be a positive integer."];
+      return 1;
+    }
+    const parsed = Number(value);
+    if (!Number.isSafeInteger(parsed)) {
+      fieldErrors.page = ["Page must be a safe positive integer."];
+      return 1;
+    }
+    return parsed;
+  };
+
+  const parsePageSize = (): 10 | 20 | 50 => {
+    const value = read("pageSize");
+    if (value === undefined) return 10;
+    if (value !== "10" && value !== "20" && value !== "50") {
+      fieldErrors.pageSize = ["Page size must be 10, 20, or 50."];
+      return 10;
+    }
+    return Number(value) as 10 | 20 | 50;
+  };
+
+  const page = parsePage();
+  const pageSize = parsePageSize();
+  if (Object.keys(fieldErrors).length > 0 || sortBy === null || sortDirection === null) return { fieldErrors };
+
+  return {
+    fieldErrors,
+    input: {
+      search,
+      categoryId,
+      relatedSystemId,
+      requestedPriority,
+      currentStatus,
+      sortBy,
+      sortDirection,
+      page,
+      pageSize,
+    },
+  };
+}
+
 function ticketResponse(ticket: {
   id: number;
   ticketNumber: string;
@@ -125,6 +256,30 @@ function ticketResponse(ticket: {
     summary: ticket.summary,
     requestedPriority: ticket.requestedPriority,
     description: ticket.description,
+    currentStatus: ticket.currentStatus,
+    createdAt: ticket.createdAt.toISOString(),
+    updatedAt: ticket.updatedAt.toISOString(),
+  };
+}
+
+function ticketSummaryResponse(ticket: {
+  id: number;
+  ticketNumber: string;
+  summary: string;
+  requestedPriority: RequestedPriority;
+  currentStatus: string;
+  createdAt: Date;
+  updatedAt: Date;
+  category: { id: number; name: string };
+  relatedSystem: { id: number; name: string };
+}) {
+  return {
+    id: ticket.id,
+    ticketNumber: ticket.ticketNumber,
+    summary: ticket.summary,
+    category: ticket.category,
+    relatedSystem: ticket.relatedSystem,
+    requestedPriority: ticket.requestedPriority,
     currentStatus: ticket.currentStatus,
     createdAt: ticket.createdAt.toISOString(),
     updatedAt: ticket.updatedAt.toISOString(),
@@ -195,6 +350,88 @@ export function createApp(prisma: ReferenceDataPrisma = getPrisma()): express.Ex
       res.status(200).json(requesters);
     } catch {
       res.status(500).json({ error: "REFERENCE_DATA_UNAVAILABLE" });
+    }
+  });
+
+  app.get("/api/tickets", async (req: Request, res: Response) => {
+    const requesterId = parseRequesterId(req);
+    if (!requesterId) {
+      return errorResponse(res, 400, "REQUESTER_CONTEXT_INVALID", "A valid Development Requester is required.");
+    }
+
+    const { input, fieldErrors } = parseTicketListQuery(req.query);
+    if (!input) return errorResponse(res, 400, "INVALID_QUERY", "Please correct the query parameters.", fieldErrors);
+
+    try {
+      const requester = await prisma.requesterUser.findFirst({
+        where: { id: requesterId, isActive: true },
+        select: { id: true },
+      });
+      if (!requester) {
+        return errorResponse(res, 400, "REQUESTER_CONTEXT_INVALID", "A valid Development Requester is required.");
+      }
+
+      const where: Prisma.TicketWhereInput = { requesterId };
+      if (input.search) {
+        where.OR = [
+          { ticketNumber: { contains: input.search, mode: "insensitive" } },
+          { summary: { contains: input.search, mode: "insensitive" } },
+        ];
+      }
+      if (input.categoryId !== null) where.categoryId = input.categoryId;
+      if (input.relatedSystemId !== null) where.relatedSystemId = input.relatedSystemId;
+      if (input.requestedPriority !== null) where.requestedPriority = input.requestedPriority;
+      if (input.currentStatus !== null) where.currentStatus = input.currentStatus;
+
+      const direction = input.sortDirection;
+      const orderBy: Prisma.TicketOrderByWithRelationInput[] = [
+        { [input.sortBy]: direction },
+        { id: direction },
+      ];
+      const [tickets, totalItems] = await Promise.all([
+        prisma.ticket.findMany({
+          where,
+          orderBy,
+          skip: (input.page - 1) * input.pageSize,
+          take: input.pageSize,
+          select: {
+            id: true,
+            ticketNumber: true,
+            summary: true,
+            requestedPriority: true,
+            currentStatus: true,
+            createdAt: true,
+            updatedAt: true,
+            category: { select: { id: true, name: true } },
+            relatedSystem: { select: { id: true, name: true } },
+          },
+        }),
+        prisma.ticket.count({ where }),
+      ]);
+
+      const totalPages = totalItems === 0 ? 0 : Math.ceil(totalItems / input.pageSize);
+      return res.status(200).json({
+        items: tickets.map(ticketSummaryResponse),
+        pagination: {
+          page: input.page,
+          pageSize: input.pageSize,
+          totalItems,
+          totalPages,
+          hasPreviousPage: input.page > 1,
+          hasNextPage: input.page < totalPages,
+        },
+        applied: {
+          search: input.search,
+          categoryId: input.categoryId,
+          relatedSystemId: input.relatedSystemId,
+          requestedPriority: input.requestedPriority,
+          currentStatus: input.currentStatus,
+          sortBy: input.sortBy,
+          sortDirection: input.sortDirection,
+        },
+      });
+    } catch {
+      return errorResponse(res, 500, "TICKET_LIST_FAILED", "Unable to load Tickets.");
     }
   });
 

--- a/server/tests/lab-02/my-tickets.api.test.ts
+++ b/server/tests/lab-02/my-tickets.api.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+import request from "supertest";
+import { createApp, type ReferenceDataPrisma } from "../../src/app.js";
+
+const ticket = {
+  id: 42,
+  ticketNumber: "TKT-2026-000042",
+  summary: "Laptop battery drains quickly",
+  requestedPriority: "HIGH" as const,
+  currentStatus: "NEW",
+  createdAt: new Date("2026-08-24T10:00:00.000Z"),
+  updatedAt: new Date("2026-08-25T10:00:00.000Z"),
+  category: { id: 2, name: "Hardware" },
+  relatedSystem: { id: 7, name: "Corporate Laptop" },
+};
+
+function makePrisma(options: { tickets?: unknown[]; totalItems?: number; inactiveRequester?: boolean; fail?: boolean } = {}) {
+  const findMany = options.fail ? vi.fn().mockRejectedValue(new Error("database unavailable")) : vi.fn().mockResolvedValue(options.tickets ?? [ticket]);
+  const count = options.fail ? vi.fn().mockRejectedValue(new Error("database unavailable")) : vi.fn().mockResolvedValue(options.totalItems ?? 1);
+  const prisma = {
+    requesterUser: {
+      findFirst: vi.fn().mockResolvedValue(options.inactiveRequester ? null : { id: 1 }),
+    },
+    ticket: {
+      findMany,
+      count,
+    },
+  } as unknown as ReferenceDataPrisma;
+  return prisma;
+}
+
+describe("GET /api/tickets", () => {
+  it("returns owner-scoped summaries with the contract defaults", async () => {
+    const prisma = makePrisma();
+    const res = await request(createApp(prisma)).get("/api/tickets").set("X-Requester-Id", "1");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      items: [{
+        id: 42,
+        ticketNumber: "TKT-2026-000042",
+        summary: "Laptop battery drains quickly",
+        category: { id: 2, name: "Hardware" },
+        relatedSystem: { id: 7, name: "Corporate Laptop" },
+        requestedPriority: "HIGH",
+        currentStatus: "NEW",
+      }],
+      pagination: { page: 1, pageSize: 10, totalItems: 1, totalPages: 1, hasPreviousPage: false, hasNextPage: false },
+      applied: {
+        search: "",
+        categoryId: null,
+        relatedSystemId: null,
+        requestedPriority: null,
+        currentStatus: null,
+        sortBy: "updatedAt",
+        sortDirection: "desc",
+      },
+    });
+    expect(prisma.ticket.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { requesterId: 1 },
+      skip: 0,
+      take: 10,
+      orderBy: [{ updatedAt: "desc" }, { id: "desc" }],
+    }));
+  });
+
+  it("applies search, filters, pagination, and deterministic sorting with AND semantics", async () => {
+    const prisma = makePrisma({ totalItems: 21 });
+    const res = await request(createApp(prisma))
+      .get("/api/tickets")
+      .set("X-Requester-Id", "1")
+      .query({
+        search: "  VPN ",
+        categoryId: "2",
+        relatedSystemId: "7",
+        requestedPriority: "URGENT",
+        currentStatus: "NEW",
+        sortBy: "ticketNumber",
+        sortDirection: "asc",
+        page: "2",
+        pageSize: "20",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.applied).toEqual({
+      search: "VPN",
+      categoryId: 2,
+      relatedSystemId: 7,
+      requestedPriority: "URGENT",
+      currentStatus: "NEW",
+      sortBy: "ticketNumber",
+      sortDirection: "asc",
+    });
+    expect(res.body.pagination).toMatchObject({ page: 2, pageSize: 20, totalItems: 21, totalPages: 2, hasPreviousPage: true, hasNextPage: false });
+    expect(prisma.ticket.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        requesterId: 1,
+        categoryId: 2,
+        relatedSystemId: 7,
+        requestedPriority: "URGENT",
+        currentStatus: "NEW",
+        OR: [
+          { ticketNumber: { contains: "VPN", mode: "insensitive" } },
+          { summary: { contains: "VPN", mode: "insensitive" } },
+        ],
+      },
+      skip: 20,
+      take: 20,
+      orderBy: [{ ticketNumber: "asc" }, { id: "asc" }],
+    }));
+  });
+
+  it("returns an empty valid page beyond the final page with accurate totals", async () => {
+    const prisma = makePrisma({ tickets: [], totalItems: 21 });
+    const res = await request(createApp(prisma)).get("/api/tickets").set("X-Requester-Id", "1").query({ page: "4", pageSize: "10" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.pagination).toEqual({ page: 4, pageSize: 10, totalItems: 21, totalPages: 3, hasPreviousPage: true, hasNextPage: false });
+  });
+
+  it("rejects missing or inactive requester context", async () => {
+    const prisma = makePrisma();
+    const missing = await request(createApp(prisma)).get("/api/tickets");
+    expect(missing.status).toBe(400);
+    expect(missing.body.error.code).toBe("REQUESTER_CONTEXT_INVALID");
+
+    const inactive = await request(createApp(makePrisma({ inactiveRequester: true }))).get("/api/tickets").set("X-Requester-Id", "1");
+    expect(inactive.status).toBe(400);
+    expect(inactive.body.error.code).toBe("REQUESTER_CONTEXT_INVALID");
+  });
+
+  it("rejects unsupported and malformed query values", async () => {
+    const prisma = makePrisma();
+    const res = await request(createApp(prisma))
+      .get("/api/tickets")
+      .set("X-Requester-Id", "1")
+      .query({ unknown: "true", categoryId: "9007199254740992", page: "0", pageSize: "15", sortDirection: ["asc", "desc"] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_QUERY");
+    expect(res.body.error.fieldErrors).toMatchObject({
+      unknown: ["This query parameter is not supported."],
+      categoryId: ["Must be a safe positive integer."],
+      page: ["Page must be a positive integer."],
+      pageSize: ["Page size must be 10, 20, or 50."],
+      sortDirection: ["This query parameter must be provided once."],
+    });
+    expect(prisma.ticket.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns a safe error when listing fails", async () => {
+    const res = await request(createApp(makePrisma({ fail: true }))).get("/api/tickets").set("X-Requester-Id", "1");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toMatchObject({ code: "TICKET_LIST_FAILED", message: "Unable to load Tickets." });
+    expect(res.body.error.correlationId).toEqual(expect.any(String));
+  });
+});


### PR DESCRIPTION
## Related Issue

Closes #20 

## Summary

This Pull Request implements the Lab 2 My Tickets API for requester-owned Ticket listing.

## Changes

- Added `GET /api/tickets`
- Added Requester context validation
- Added owner-scoped Ticket queries
- Added search by Ticket Number and Summary
- Added Category, Related System, Priority, and Status filters
- Added sorting by creation date, update date, and Ticket Number
- Added ascending and descending sort direction
- Added pagination with page sizes 10, 20, and 50
- Added deterministic tie-breaking by Ticket ID
- Added validation for unsupported and malformed query parameters
- Added safe `TICKET_LIST_FAILED` error responses
- Added automated API tests

## Verification

- `npm test`
- `npm run build`

All 36 tests pass.

## API Behavior

- Valid request returns `200`
- Results contain only the selected Requester’s Tickets
- Search and filters use AND semantics
- Search is case-insensitive and trimmed
- A page beyond the final page returns an empty list with accurate totals
- Invalid query returns `400 INVALID_QUERY`
- Missing or inactive Requester returns `400 REQUESTER_CONTEXT_INVALID`
- Database failure returns `500 TICKET_LIST_FAILED`

## Out of Scope

- Ticket detail
- Attachments
- UI implementation
- Authentication