### PR TITLE
Lab 2: Add Ticket Detail API

### DIFF
--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -57,8 +57,8 @@ Database tests use a dedicated test database/schema. Attachment tests use a task
 | API-18 | BR-27-BR-28, AC-17, AC-19 | Page beyond final/owner empty | `200` empty with accurate totals | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
 | API-19 | FR-20, BR-27, AC-18 | Invalid/unknown query | Safe `400 INVALID_QUERY` | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
 | API-20 | FR-20, BR-41, AC-18 | Ticket-list database failure | Safe `500` with no internals | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
-| API-21 | FR-22, AC-20 | Owned Ticket Detail | `200`; approved detail/metadata shape | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
-| API-22 | FR-23, BR-07-BR-08, AC-21 | Missing/cross-owner Ticket | Same safe `404`; no owner data | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
+| API-21 | FR-22, AC-20 | Owned Ticket Detail | `200`; approved detail/metadata shape | `server/tests/lab-02/ticket-detail.api.test.ts` | PASS |
+| API-22 | FR-23, BR-07-BR-08, AC-21 | Missing/cross-owner Ticket | Same safe `404`; no owner data | `server/tests/lab-02/ticket-detail.api.test.ts` | PASS |
 | API-23 | FR-25, BR-29-BR-35, AC-22 | Valid types and exact 5 MiB upload | `201`; one active row/file | `server/tests/lab-02/attachments.api.test.ts` | Planned |
 | API-24 | BR-29-BR-32, AC-23 | Type/signature mismatch and >5 MiB | `415`/`413`; no row/file | `server/tests/lab-02/attachments.api.test.ts` | Planned |
 | API-25 | BR-31, AC-23 | Fifth/sixth active Attachment | Fifth accepted; sixth `409`; removed excluded | `server/tests/lab-02/attachments.api.test.ts` | Planned |
@@ -192,7 +192,15 @@ Focused commands belong in Issue/PR evidence; final evidence must come from comp
 
 ### Lab 2
 
-**Status:** Not run.
+**Status:** Feature 10 Ticket Detail API verified on branch `feature/10-lab2-ticket-detail-api`.
+
+### Feature 10 Evidence
+
+- Implementation and integration-test commit: `3e8e6c2`.
+- `npm test` with `RUN_DB_INTEGRATION=1`: **42 tests passed**.
+- `npm run build`: **passed**.
+- PostgreSQL integration covers owned detail, A/B owner isolation, active/removed Attachment ordering, and safe 404 behavior.
+- Hosted evidence is provided by GitHub Actions workflow `Server CI` in `.github/workflows/server-ci.yml`; the post-fix run will execute on PR #23 after this branch is pushed.
 
 ## 10. Known Limitations and Deferred Tests
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -497,6 +497,14 @@ export function createApp(prisma: ReferenceDataPrisma = getPrisma()): express.Ex
     const ticketId = Number(ticketIdValue);
 
     try {
+      const requester = await prisma.requesterUser.findFirst({
+        where: { id: requesterId, isActive: true },
+        select: { id: true },
+      });
+      if (!requester) {
+        return errorResponse(res, 400, "REQUESTER_CONTEXT_INVALID", "A valid Development Requester is required.");
+      }
+
       const ticket = await prisma.ticket.findFirst({
         where: { id: ticketId, requesterId },
         select: {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -286,6 +286,55 @@ function ticketSummaryResponse(ticket: {
   };
 }
 
+function ticketDetailResponse(ticket: {
+  id: number;
+  ticketNumber: string;
+  createdAt: Date;
+  updatedAt: Date;
+  summary: string;
+  description: string;
+  requestedPriority: RequestedPriority;
+  currentStatus: string;
+  requester: { id: number; name: string; email: string };
+  category: { id: number; name: string };
+  relatedSystem: { id: number; name: string };
+  attachments: Array<{
+    id: number;
+    originalName: string;
+    mimeType: string;
+    sizeBytes: number;
+    uploadedAt: Date;
+    removedAt: Date | null;
+    removedReason: string | null;
+  }>;
+}) {
+  return {
+    id: ticket.id,
+    ticketNumber: ticket.ticketNumber,
+    ticketDate: ticket.createdAt.toISOString(),
+    requester: ticket.requester,
+    category: ticket.category,
+    relatedSystem: ticket.relatedSystem,
+    summary: ticket.summary,
+    requestedPriority: ticket.requestedPriority,
+    description: ticket.description,
+    currentStatus: ticket.currentStatus,
+    createdAt: ticket.createdAt.toISOString(),
+    updatedAt: ticket.updatedAt.toISOString(),
+    attachments: ticket.attachments.map((attachment) => ({
+      id: attachment.id,
+      originalName: attachment.originalName,
+      mimeType: attachment.mimeType,
+      sizeBytes: attachment.sizeBytes,
+      state: attachment.removedAt ? "REMOVED" : "ACTIVE",
+      uploadedAt: attachment.uploadedAt.toISOString(),
+      removedAt: attachment.removedAt?.toISOString() ?? null,
+      removedReason: attachment.removedReason,
+      downloadUrl: attachment.removedAt ? null : `/api/tickets/${ticket.id}/attachments/${attachment.id}/download`,
+    })),
+  };
+}
+
 function isIdempotencyUniqueViolation(error: unknown): error is Prisma.PrismaClientKnownRequestError {
   if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== "P2002") return false;
   const target = error.meta?.target;
@@ -432,6 +481,54 @@ export function createApp(prisma: ReferenceDataPrisma = getPrisma()): express.Ex
       });
     } catch {
       return errorResponse(res, 500, "TICKET_LIST_FAILED", "Unable to load Tickets.");
+    }
+  });
+
+  app.get("/api/tickets/:ticketId", async (req: Request, res: Response) => {
+    const requesterId = parseRequesterId(req);
+    if (!requesterId) {
+      return errorResponse(res, 400, "REQUESTER_CONTEXT_INVALID", "A valid Development Requester is required.");
+    }
+
+    const ticketIdValue = req.params.ticketId;
+    if (!/^[1-9]\d*$/.test(ticketIdValue) || !Number.isSafeInteger(Number(ticketIdValue))) {
+      return errorResponse(res, 400, "INVALID_TICKET_ID", "Ticket ID must be a positive integer.");
+    }
+    const ticketId = Number(ticketIdValue);
+
+    try {
+      const ticket = await prisma.ticket.findFirst({
+        where: { id: ticketId, requesterId },
+        select: {
+          id: true,
+          ticketNumber: true,
+          createdAt: true,
+          updatedAt: true,
+          summary: true,
+          description: true,
+          requestedPriority: true,
+          currentStatus: true,
+          requester: { select: { id: true, name: true, email: true } },
+          category: { select: { id: true, name: true } },
+          relatedSystem: { select: { id: true, name: true } },
+          attachments: {
+            orderBy: [{ uploadedAt: "asc" }, { id: "asc" }],
+            select: {
+              id: true,
+              originalName: true,
+              mimeType: true,
+              sizeBytes: true,
+              uploadedAt: true,
+              removedAt: true,
+              removedReason: true,
+            },
+          },
+        },
+      });
+      if (!ticket) return errorResponse(res, 404, "RESOURCE_NOT_FOUND", "Ticket not found.");
+      return res.status(200).json(ticketDetailResponse(ticket));
+    } catch {
+      return errorResponse(res, 500, "TICKET_DETAIL_FAILED", "Unable to load Ticket details.");
     }
   });
 

--- a/server/tests/lab-02/ticket-detail.api.test.ts
+++ b/server/tests/lab-02/ticket-detail.api.test.ts
@@ -48,6 +48,9 @@ function makeTicket() {
 function makePrisma(options: { ticket?: unknown; fail?: boolean } = {}) {
   const ticketResult = Object.prototype.hasOwnProperty.call(options, "ticket") ? options.ticket : makeTicket();
   const prisma = {
+    requesterUser: {
+      findFirst: options.fail ? vi.fn().mockRejectedValue(new Error("database unavailable")) : vi.fn().mockResolvedValue({ id: 1 }),
+    },
     ticket: {
       findFirst: options.fail ? vi.fn().mockRejectedValue(new Error("database unavailable")) : vi.fn().mockResolvedValue(ticketResult),
     },
@@ -132,6 +135,23 @@ describe("GET /api/tickets/:ticketId", () => {
     expect(unsafeTicket.status).toBe(400);
     expect(unsafeTicket.body.error.code).toBe("INVALID_TICKET_ID");
     expect(prisma.ticket.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown or inactive Requester before querying Ticket data", async () => {
+    const unknownPrisma = makePrisma();
+    vi.mocked(unknownPrisma.requesterUser.findFirst).mockResolvedValue(null);
+    const unknown = await request(createApp(unknownPrisma)).get("/api/tickets/42").set("X-Requester-Id", "999");
+
+    const inactivePrisma = makePrisma();
+    vi.mocked(inactivePrisma.requesterUser.findFirst).mockResolvedValue(null);
+    const inactive = await request(createApp(inactivePrisma)).get("/api/tickets/42").set("X-Requester-Id", "1");
+
+    expect(unknown.status).toBe(400);
+    expect(inactive.status).toBe(400);
+    expect(unknown.body.error.code).toBe("REQUESTER_CONTEXT_INVALID");
+    expect(inactive.body.error.code).toBe("REQUESTER_CONTEXT_INVALID");
+    expect(unknownPrisma.ticket.findFirst).not.toHaveBeenCalled();
+    expect(inactivePrisma.ticket.findFirst).not.toHaveBeenCalled();
   });
 
   it("returns a safe error when detail lookup fails", async () => {

--- a/server/tests/lab-02/ticket-detail.api.test.ts
+++ b/server/tests/lab-02/ticket-detail.api.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import request from "supertest";
+import { createApp, type ReferenceDataPrisma } from "../../src/app.js";
+
+const createdAt = new Date("2026-08-24T10:00:00.000Z");
+const updatedAt = new Date("2026-08-25T10:00:00.000Z");
+
+function makeTicket() {
+  return {
+    id: 42,
+    ticketNumber: "TKT-2026-000042",
+    requesterId: 1,
+    summary: "Laptop battery drains quickly",
+    description: "Battery drops from full to empty in about one hour.",
+    requestedPriority: "MEDIUM" as const,
+    currentStatus: "NEW",
+    createdAt,
+    updatedAt,
+    requestPayloadHash: "private-hash",
+    requester: { id: 1, name: "Anan Srisuk", email: "anan.srisuk@example.test" },
+    category: { id: 2, name: "Hardware" },
+    relatedSystem: { id: 7, name: "Corporate Laptop" },
+    attachments: [
+      {
+        id: 10,
+        originalName: "battery-report.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 205120,
+        uploadedAt: new Date("2026-08-24T10:02:00.000Z"),
+        removedAt: null,
+        removedReason: null,
+        storageKey: "private-storage-key",
+      },
+      {
+        id: 11,
+        originalName: "old-log.txt",
+        mimeType: "text/plain",
+        sizeBytes: 1200,
+        uploadedAt: new Date("2026-08-24T10:03:00.000Z"),
+        removedAt: new Date("2026-08-25T09:00:00.000Z"),
+        removedReason: "Duplicate file",
+        storageKey: "private-storage-key-2",
+      },
+    ],
+  };
+}
+
+function makePrisma(options: { ticket?: unknown; fail?: boolean } = {}) {
+  const ticketResult = Object.prototype.hasOwnProperty.call(options, "ticket") ? options.ticket : makeTicket();
+  const prisma = {
+    ticket: {
+      findFirst: options.fail ? vi.fn().mockRejectedValue(new Error("database unavailable")) : vi.fn().mockResolvedValue(ticketResult),
+    },
+  } as unknown as ReferenceDataPrisma;
+  return prisma;
+}
+
+describe("GET /api/tickets/:ticketId", () => {
+  it("returns owned Ticket detail with safe active and removed Attachment metadata", async () => {
+    const prisma = makePrisma();
+    const res = await request(createApp(prisma)).get("/api/tickets/42").set("X-Requester-Id", "1");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      id: 42,
+      ticketNumber: "TKT-2026-000042",
+      ticketDate: "2026-08-24T10:00:00.000Z",
+      requester: { id: 1, name: "Anan Srisuk", email: "anan.srisuk@example.test" },
+      category: { id: 2, name: "Hardware" },
+      relatedSystem: { id: 7, name: "Corporate Laptop" },
+      summary: "Laptop battery drains quickly",
+      requestedPriority: "MEDIUM",
+      description: "Battery drops from full to empty in about one hour.",
+      currentStatus: "NEW",
+      createdAt: "2026-08-24T10:00:00.000Z",
+      updatedAt: "2026-08-25T10:00:00.000Z",
+      attachments: [
+        {
+          id: 10,
+          originalName: "battery-report.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 205120,
+          state: "ACTIVE",
+          uploadedAt: "2026-08-24T10:02:00.000Z",
+          removedAt: null,
+          removedReason: null,
+          downloadUrl: "/api/tickets/42/attachments/10/download",
+        },
+        {
+          id: 11,
+          originalName: "old-log.txt",
+          mimeType: "text/plain",
+          sizeBytes: 1200,
+          state: "REMOVED",
+          uploadedAt: "2026-08-24T10:03:00.000Z",
+          removedAt: "2026-08-25T09:00:00.000Z",
+          removedReason: "Duplicate file",
+          downloadUrl: null,
+        },
+      ],
+    });
+    expect(res.body.requestPayloadHash).toBeUndefined();
+    expect(res.body.attachments[0].storageKey).toBeUndefined();
+    expect(prisma.ticket.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 42, requesterId: 1 },
+      select: expect.objectContaining({
+        attachments: { orderBy: [{ uploadedAt: "asc" }, { id: "asc" }], select: expect.any(Object) },
+      }),
+    }));
+  });
+
+  it("returns the same safe 404 for missing and non-owned Tickets", async () => {
+    const missing = await request(createApp(makePrisma({ ticket: null }))).get("/api/tickets/42").set("X-Requester-Id", "1");
+    const nonOwned = await request(createApp(makePrisma({ ticket: null }))).get("/api/tickets/42").set("X-Requester-Id", "2");
+
+    expect(missing.status).toBe(404);
+    expect(nonOwned.status).toBe(404);
+    expect(missing.body).toEqual({ error: { code: "RESOURCE_NOT_FOUND", message: "Ticket not found." } });
+    expect(nonOwned.body).toEqual(missing.body);
+  });
+
+  it("rejects missing or malformed Requester and Ticket context", async () => {
+    const prisma = makePrisma();
+    const missingRequester = await request(createApp(prisma)).get("/api/tickets/42");
+    const malformedTicket = await request(createApp(prisma)).get("/api/tickets/0").set("X-Requester-Id", "1");
+    const unsafeTicket = await request(createApp(prisma)).get("/api/tickets/9007199254740992").set("X-Requester-Id", "1");
+
+    expect(missingRequester.status).toBe(400);
+    expect(missingRequester.body.error.code).toBe("REQUESTER_CONTEXT_INVALID");
+    expect(malformedTicket.status).toBe(400);
+    expect(malformedTicket.body.error.code).toBe("INVALID_TICKET_ID");
+    expect(unsafeTicket.status).toBe(400);
+    expect(unsafeTicket.body.error.code).toBe("INVALID_TICKET_ID");
+    expect(prisma.ticket.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns a safe error when detail lookup fails", async () => {
+    const res = await request(createApp(makePrisma({ fail: true }))).get("/api/tickets/42").set("X-Requester-Id", "1");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toMatchObject({ code: "TICKET_DETAIL_FAILED", message: "Unable to load Ticket details." });
+    expect(res.body.error.correlationId).toEqual(expect.any(String));
+  });
+});

--- a/server/tests/lab-02/ticket-detail.postgres.integration.test.ts
+++ b/server/tests/lab-02/ticket-detail.postgres.integration.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import request from "supertest";
+import { randomUUID } from "node:crypto";
+import { Prisma, PrismaClient } from "@prisma/client";
+import { createApp } from "../../src/app.js";
+
+const runIntegration = process.env.RUN_DB_INTEGRATION === "1" && Boolean(process.env.DATABASE_URL);
+const integration = runIntegration ? describe : describe.skip;
+
+integration("GET /api/tickets/:ticketId PostgreSQL integration", () => {
+  let prisma: PrismaClient;
+  let requesterA: number;
+  let requesterB: number;
+  let categoryId: number;
+  let relatedSystemId: number;
+  let ticketId: number;
+
+  beforeAll(async () => {
+    prisma = new PrismaClient();
+    await prisma.$connect();
+    const [requesters, category, relatedSystem] = await Promise.all([
+      prisma.requesterUser.findMany({ where: { isActive: true }, select: { id: true }, orderBy: { id: "asc" }, take: 2 }),
+      prisma.category.findFirst({ where: { isActive: true }, select: { id: true } }),
+      prisma.relatedSystem.findFirst({ where: { isActive: true }, select: { id: true } }),
+    ]);
+    if (requesters.length < 2 || !category || !relatedSystem) {
+      throw new Error("Integration test requires two active Requesters and seeded reference data.");
+    }
+    requesterA = requesters[0].id;
+    requesterB = requesters[1].id;
+    categoryId = category.id;
+    relatedSystemId = relatedSystem.id;
+
+    const [{ nextval }] = await prisma.$queryRaw<Array<{ nextval: bigint }>>(
+      Prisma.sql`SELECT nextval('"TicketNumberSequence"')`,
+    );
+    const created = await prisma.ticket.create({
+      data: {
+        ticketNumber: `TKT-${new Date().getUTCFullYear()}-${nextval.toString().padStart(6, "0")}`,
+        requesterId: requesterA,
+        categoryId,
+        relatedSystemId,
+        summary: "Ticket detail integration fixture",
+        description: "Fixture for owner isolation and Attachment ordering.",
+        requestedPriority: "HIGH",
+        currentStatus: "NEW",
+        clientRequestId: randomUUID(),
+        requestPayloadHash: "a".repeat(64),
+        attachments: {
+          create: [
+            {
+              originalName: "first.txt",
+              storageKey: randomUUID(),
+              mimeType: "text/plain",
+              sizeBytes: 10,
+              uploadedAt: new Date("2026-08-24T10:00:00.000Z"),
+            },
+            {
+              originalName: "removed.txt",
+              storageKey: randomUUID(),
+              mimeType: "text/plain",
+              sizeBytes: 20,
+              uploadedAt: new Date("2026-08-24T10:00:00.000Z"),
+              removedAt: new Date("2026-08-25T10:00:00.000Z"),
+              removedReason: "No longer needed",
+              removedByRequesterId: requesterA,
+            },
+          ],
+        },
+      },
+    });
+    ticketId = created.id;
+  });
+
+  afterAll(async () => {
+    if (!prisma) return;
+    if (ticketId) await prisma.ticket.delete({ where: { id: ticketId } });
+    await prisma.$disconnect();
+  });
+
+  it("returns ordered details to the owner and safely rejects another owner", async () => {
+    const app = createApp(prisma);
+    const owned = await request(app).get(`/api/tickets/${ticketId}`).set("X-Requester-Id", String(requesterA));
+    expect(owned.status).toBe(200);
+    expect(owned.body.attachments.map((attachment: { originalName: string }) => attachment.originalName)).toEqual(["first.txt", "removed.txt"]);
+    expect(owned.body.attachments[0]).toMatchObject({ state: "ACTIVE", downloadUrl: `/api/tickets/${ticketId}/attachments/${owned.body.attachments[0].id}/download` });
+    expect(owned.body.attachments[1]).toMatchObject({ state: "REMOVED", downloadUrl: null, removedReason: "No longer needed" });
+    expect(owned.body.attachments[0].storageKey).toBeUndefined();
+    expect(owned.body.requestPayloadHash).toBeUndefined();
+
+    const nonOwner = await request(app).get(`/api/tickets/${ticketId}`).set("X-Requester-Id", String(requesterB));
+    expect(nonOwner.status).toBe(404);
+    expect(nonOwner.body).toEqual({ error: { code: "RESOURCE_NOT_FOUND", message: "Ticket not found." } });
+  });
+});


### PR DESCRIPTION
## Related Issue

Closes #22

## Summary

This Pull Request implements the requester-owned Ticket Detail API for Lab 2.

## Changes

- Added `GET /api/tickets/:ticketId`
- Added Requester ownership validation
- Added read-only Ticket detail response
- Added active and removed Attachment metadata
- Hid sensitive storage and payload fields
- Added safe 400, 404, and 500 responses
- Added automated API tests

## Verification

- `npm test`
- `npm run build`

39 tests pass.

## Out of Scope

- Attachment upload
- Attachment download
- Attachment removal
- UI implementation
- Authentication