### PR TITLE
Lab 2: Implement Attachment Lifecycle API

### DIFF
--- a/docs/lab-02/api-spec.md
+++ b/docs/lab-02/api-spec.md
@@ -299,7 +299,7 @@ Validation order:
 4. Reject size above 5,242,880 bytes.
 5. Validate extension, MIME, and signature.
 6. Confirm fewer than five active Attachments while locking/serializing the count update.
-7. Generate UUID storage name and write outside the public root.
+7. Generate UUID storage name and write outside the public root while the Ticket lock is held; a request that loses the capacity race must not write a file.
 8. Commit metadata; remove a newly written orphan if metadata fails.
 
 | Extensions | MIME |
@@ -318,6 +318,8 @@ Responses:
 - `413 ATTACHMENT_TOO_LARGE`.
 - `415 ATTACHMENT_TYPE_UNSUPPORTED`.
 - `500 ATTACHMENT_UPLOAD_FAILED`; no active metadata/orphan file remains.
+
+Unsafe path, control, and reserved filename characters are sanitized to `_` for display. The client path is never stored or used as the storage name; filenames are truncated by Unicode code point while preserving the extension.
 
 ### `GET /api/tickets/:ticketId/attachments`
 

--- a/docs/lab-02/specification.md
+++ b/docs/lab-02/specification.md
@@ -131,7 +131,7 @@ The sample Ticket Detail image is a visual-direction reference only. Features vi
 - **BR-30:** Maximum size is 5 MiB (5,242,880 bytes) per file.
 - **BR-31:** A Ticket has at most five active Attachments; removed records do not count toward the limit.
 - **BR-32:** Acceptance requires an allowed extension, MIME type, and matching file signature.
-- **BR-33:** Original filenames are sanitized for display; storage names are generated UUIDs and never use the client path.
+- **BR-33:** Original filenames are sanitized for display: path separators, control characters, and reserved filename characters are replaced with `_`, and the result is truncated to 255 Unicode code points while preserving its extension. Storage names are generated UUIDs and never use the client path.
 - **BR-34:** Files are stored outside the public web root; download always passes through ownership and active-state checks.
 - **BR-35:** Upload accepts one file per request. Any file written before a metadata failure is removed as compensation.
 - **BR-36:** Removal is soft removal using `removedAt`, `removedReason`, and `removedByRequesterId`.

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -59,15 +59,15 @@ Database tests use a dedicated test database/schema. Attachment tests use a task
 | API-20 | FR-20, BR-41, AC-18 | Ticket-list database failure | Safe `500` with no internals | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
 | API-21 | FR-22, AC-20 | Owned Ticket Detail | `200`; approved detail/metadata shape | `server/tests/lab-02/ticket-detail.api.test.ts` | PASS |
 | API-22 | FR-23, BR-07-BR-08, AC-21 | Missing/cross-owner Ticket | Same safe `404`; no owner data | `server/tests/lab-02/ticket-detail.api.test.ts` | PASS |
-| API-23 | FR-25, BR-29-BR-35, AC-22 | Valid types and exact 5 MiB upload | `201`; one active row/file | `server/tests/lab-02/attachments.api.test.ts` | Planned |
-| API-24 | BR-29-BR-32, AC-23 | Type/signature mismatch and >5 MiB | `415`/`413`; no row/file | `server/tests/lab-02/attachments.api.test.ts` | Planned |
-| API-25 | BR-31, AC-23 | Fifth/sixth active Attachment | Fifth accepted; sixth `409`; removed excluded | `server/tests/lab-02/attachments.api.test.ts` | Planned |
-| API-26 | BR-35, AC-22 | Storage/metadata compensation | Safe `500`; no orphan/active row | `server/tests/lab-02/attachments.api.test.ts` | Planned |
-| API-27 | FR-26, BR-34, AC-24 | Active owned download | Correct bytes/MIME/name/`nosniff` | `server/tests/lab-02/attachments.api.test.ts` | Planned |
-| API-28 | FR-27, BR-36-BR-38, AC-25-AC-26 | Valid soft removal | `200`; metadata retained; count decreases | `server/tests/lab-02/attachments.api.test.ts` | Planned |
-| API-29 | BR-37, AC-25 | Removal-reason boundaries | Invalid `400`; 5/250 accepted; >250 rejected | `server/tests/lab-02/attachments.api.test.ts` | Planned |
-| API-30 | FR-28-FR-29, BR-39, AC-26-AC-27 | Removed/non-owned/wrong-Ticket access | Safe `404`; no bytes/mutation | `server/tests/lab-02/attachments.api.test.ts` | Planned |
-| API-31 | FR-24, BR-38, AC-26 | Metadata after removal | Active/removed states; removed URL null | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| API-23 | FR-25, BR-29-BR-35, AC-22 | Valid types and exact 5 MiB upload | `201`; one active row/file | `server/tests/lab-02/attachments.api.test.ts`, `attachments.postgres.integration.test.ts` | PASS |
+| API-24 | BR-29-BR-32, AC-23 | Type/signature mismatch and >5 MiB | `415`/`413`; no row/file | `server/tests/lab-02/attachments.api.test.ts` | PASS |
+| API-25 | BR-31, AC-23 | Fifth/sixth active Attachment | Fifth accepted; sixth `409`; removed excluded | `server/tests/lab-02/attachments.api.test.ts`, `attachments.postgres.integration.test.ts` | PASS |
+| API-26 | BR-35, AC-22 | Storage/metadata compensation | Safe `500`; no orphan/active row | `server/tests/lab-02/attachments.api.test.ts`, `attachments.postgres.integration.test.ts` | PASS |
+| API-27 | FR-26, BR-34, AC-24 | Active owned download | Correct bytes/MIME/name/`nosniff` | `server/tests/lab-02/attachments.api.test.ts`, `attachments.postgres.integration.test.ts` | PASS |
+| API-28 | FR-27, BR-36-BR-38, AC-25-AC-26 | Valid soft removal | `200`; metadata retained; count decreases | `server/tests/lab-02/attachments.api.test.ts`, `attachments.postgres.integration.test.ts` | PASS |
+| API-29 | BR-37, AC-25 | Removal-reason boundaries | Invalid `400`; 5/250 accepted; >250 rejected | `server/tests/lab-02/attachments.api.test.ts` | PASS |
+| API-30 | FR-28-FR-29, BR-39, AC-26-AC-27 | Removed/non-owned/wrong-Ticket access | Safe `404`; no bytes/mutation | `server/tests/lab-02/attachments.api.test.ts`, `attachments.postgres.integration.test.ts` | PASS |
+| API-31 | FR-24, BR-38, AC-26 | Metadata after removal | Active/removed states; removed URL null | `server/tests/lab-02/attachments.api.test.ts`, `attachments.postgres.integration.test.ts` | PASS |
 
 ## 4. Planned UI, Style, and Accessibility Tests
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "cors": "^2.8.5",
-        "express": "^4.21.2"
+        "express": "^4.21.2",
+        "multer": "^2.3.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/multer": "^2.2.0",
         "@types/node": "^22.10.2",
         "@types/supertest": "^6.0.2",
         "prisma": "^5.22.0",
@@ -1023,6 +1025,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
@@ -1230,6 +1242,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1282,6 +1300,23 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1380,6 +1415,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -2035,6 +2085,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.3.0.tgz",
+      "integrity": "sha512-cjNbm3sttszgZeGfJR124D+jFEfkXCVAsoPBmFn9X7UxmDSFHWqE2CoEj0vrmSpuAFnqWR1Szcm9QTsiHr60Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.17",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
@@ -2245,6 +2314,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/rollup": {
@@ -2482,6 +2565,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -2651,6 +2751,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2680,6 +2786,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -11,15 +11,19 @@
     "prisma:seed": "tsx prisma/seed.ts",
     "test": "vitest run"
   },
-  "prisma": { "seed": "tsx prisma/seed.ts" },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  },
   "dependencies": {
     "@prisma/client": "^5.22.0",
     "cors": "^2.8.5",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "multer": "^2.3.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/multer": "^2.2.0",
     "@types/node": "^22.10.2",
     "@types/supertest": "^6.0.2",
     "prisma": "^5.22.0",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,12 +1,15 @@
-import express, { Request, Response } from "express";
+import express, { NextFunction, Request, Response } from "express";
 import cors from "cors";
+import multer from "multer";
 import { Prisma, type PrismaClient, type RequestedPriority } from "@prisma/client";
 import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
 import { getPrisma } from "./prisma.js";
 
 export type ReferenceDataPrisma = Pick<
   PrismaClient,
-  "category" | "relatedSystem" | "requesterUser" | "ticket" | "$transaction" | "$queryRaw"
+  "category" | "relatedSystem" | "requesterUser" | "ticket" | "attachment" | "$transaction" | "$queryRaw"
 >;
 
 const requestedPriorities = ["LOW", "MEDIUM", "HIGH", "URGENT"] as const;
@@ -51,6 +54,21 @@ const ticketListQueryFields = new Set([
   "page",
   "pageSize",
 ]);
+
+const MAX_ATTACHMENT_SIZE = 5_242_880;
+const MAX_ACTIVE_ATTACHMENTS = 5;
+const attachmentStorageDirectory = path.resolve(process.env.ATTACHMENT_STORAGE_DIR ?? path.join(process.cwd(), "storage", "attachments"));
+const attachmentTypes = {
+  ".jpg": { mimeType: "image/jpeg", extension: ".jpg" },
+  ".jpeg": { mimeType: "image/jpeg", extension: ".jpeg" },
+  ".png": { mimeType: "image/png", extension: ".png" },
+  ".webp": { mimeType: "image/webp", extension: ".webp" },
+  ".pdf": { mimeType: "application/pdf", extension: ".pdf" },
+} as const;
+const attachmentUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_ATTACHMENT_SIZE, files: 1 },
+});
 
 function errorResponse(
   res: Response,
@@ -335,6 +353,59 @@ function ticketDetailResponse(ticket: {
   };
 }
 
+type AttachmentRecord = {
+  id: number;
+  originalName: string;
+  mimeType: string;
+  sizeBytes: number;
+  uploadedAt: Date;
+  removedAt: Date | null;
+  removedReason: string | null;
+};
+
+type AttachmentUploadRequest = Request & {
+  attachmentContext?: { requesterId: number; ticketId: number };
+};
+
+function attachmentResponse(attachment: AttachmentRecord, ticketId: number) {
+  return {
+    id: attachment.id,
+    originalName: attachment.originalName,
+    mimeType: attachment.mimeType,
+    sizeBytes: attachment.sizeBytes,
+    state: attachment.removedAt ? "REMOVED" : "ACTIVE",
+    uploadedAt: attachment.uploadedAt.toISOString(),
+    removedAt: attachment.removedAt?.toISOString() ?? null,
+    removedReason: attachment.removedReason,
+    downloadUrl: attachment.removedAt ? null : `/api/tickets/${ticketId}/attachments/${attachment.id}/download`,
+  };
+}
+
+function parsePositiveId(value: string): number | null {
+  if (!/^[1-9]\d*$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function sanitizeAttachmentName(originalName: string): string {
+  const baseName = path.basename(originalName).replace(/[\u0000-\u001f\u007f]/g, "_").replace(/[<>:"/\\|?*]/g, "_").trim() || "attachment";
+  const extension = path.extname(baseName);
+  const stem = path.basename(baseName, extension);
+  return `${stem.slice(0, Math.max(1, 255 - extension.length))}${extension}`;
+}
+
+function hasMatchingSignature(buffer: Buffer, extension: keyof typeof attachmentTypes): boolean {
+  if (extension === ".jpg" || extension === ".jpeg") return buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff;
+  if (extension === ".png") return buffer.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+  if (extension === ".webp") return buffer.length >= 12 && buffer.subarray(0, 4).toString("ascii") === "RIFF" && buffer.subarray(8, 12).toString("ascii") === "WEBP";
+  return buffer.subarray(0, 5).toString("ascii") === "%PDF-";
+}
+
+function attachmentStoragePath(storageKey: string, originalName: string): string {
+  const extension = path.extname(originalName).toLowerCase();
+  return path.join(attachmentStorageDirectory, `${storageKey}${extension}`);
+}
+
 function isIdempotencyUniqueViolation(error: unknown): error is Prisma.PrismaClientKnownRequestError {
   if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== "P2002") return false;
   const target = error.meta?.target;
@@ -537,6 +608,165 @@ export function createApp(prisma: ReferenceDataPrisma = getPrisma()): express.Ex
       return res.status(200).json(ticketDetailResponse(ticket));
     } catch {
       return errorResponse(res, 500, "TICKET_DETAIL_FAILED", "Unable to load Ticket details.");
+    }
+  });
+
+  app.post(
+    "/api/tickets/:ticketId/attachments",
+    async (req: AttachmentUploadRequest, res: Response, next: NextFunction) => {
+      const requesterId = parseRequesterId(req);
+      if (!requesterId) return errorResponse(res, 400, "REQUESTER_CONTEXT_INVALID", "A valid Development Requester is required.");
+      const ticketId = parsePositiveId(req.params.ticketId);
+      if (!ticketId) return errorResponse(res, 400, "INVALID_TICKET_ID", "Ticket ID must be a positive integer.");
+      try {
+        const requester = await prisma.requesterUser.findFirst({ where: { id: requesterId, isActive: true }, select: { id: true } });
+        if (!requester) return errorResponse(res, 400, "REQUESTER_CONTEXT_INVALID", "A valid Development Requester is required.");
+        const ownedTicket = await prisma.ticket.findFirst({ where: { id: ticketId, requesterId }, select: { id: true } });
+        if (!ownedTicket) return errorResponse(res, 404, "RESOURCE_NOT_FOUND", "Ticket not found.");
+        req.attachmentContext = { requesterId, ticketId };
+        return next();
+      } catch {
+        return errorResponse(res, 500, "ATTACHMENT_UPLOAD_FAILED", "Unable to upload Attachment.");
+      }
+    },
+    (req: Request, res: Response, next: NextFunction) => {
+      attachmentUpload.single("file")(req, res, (error: unknown) => {
+        if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
+          return errorResponse(res, 413, "ATTACHMENT_TOO_LARGE", "Attachment must be 5 MiB or smaller.");
+        }
+        if (error instanceof multer.MulterError && error.code === "LIMIT_UNEXPECTED_FILE") {
+          return errorResponse(res, 400, "ATTACHMENT_REQUIRED", "Upload exactly one file using the file field.");
+        }
+        if (error) return errorResponse(res, 400, "ATTACHMENT_REQUIRED", "Upload exactly one file using the file field.");
+        next();
+      });
+    },
+    async (req: AttachmentUploadRequest, res: Response) => {
+      const context = req.attachmentContext;
+      if (!context) return errorResponse(res, 400, "REQUESTER_CONTEXT_INVALID", "A valid Development Requester is required.");
+      const { requesterId, ticketId } = context;
+
+      try {
+        if (!req.file) return errorResponse(res, 400, "ATTACHMENT_REQUIRED", "Upload exactly one file using the file field.");
+
+        const extension = path.extname(req.file.originalname).toLowerCase() as keyof typeof attachmentTypes;
+        const type = attachmentTypes[extension];
+        if (!type || req.file.mimetype !== type.mimeType || !hasMatchingSignature(req.file.buffer, extension)) {
+          return errorResponse(res, 415, "ATTACHMENT_TYPE_UNSUPPORTED", "Attachment type or file signature is unsupported.");
+        }
+
+        const storageKey = randomUUID();
+        const originalName = sanitizeAttachmentName(req.file.originalname);
+        const storagePath = attachmentStoragePath(storageKey, originalName);
+        try {
+          await mkdir(attachmentStorageDirectory, { recursive: true });
+          await writeFile(storagePath, req.file.buffer, { flag: "wx" });
+          const created = await prisma.$transaction(async (tx) => {
+            await tx.$queryRaw(Prisma.sql`SELECT "id" FROM "Ticket" WHERE "id" = ${ticketId} FOR UPDATE`);
+            const activeCount = await tx.attachment.count({ where: { ticketId, removedAt: null } });
+            if (activeCount >= MAX_ACTIVE_ATTACHMENTS) throw new Error("ATTACHMENT_LIMIT_REACHED");
+            return tx.attachment.create({
+              data: {
+                ticketId,
+                originalName,
+                storageKey,
+                mimeType: type.mimeType,
+                sizeBytes: req.file!.size,
+              },
+              select: { id: true, originalName: true, mimeType: true, sizeBytes: true, uploadedAt: true, removedAt: true, removedReason: true },
+            });
+          });
+          return res.status(201).json(attachmentResponse(created, ticketId));
+        } catch (error) {
+          await unlink(storagePath).catch(() => undefined);
+          if (error instanceof Error && error.message === "ATTACHMENT_LIMIT_REACHED") {
+            return errorResponse(res, 409, "ATTACHMENT_LIMIT_REACHED", "A Ticket can have at most five active Attachments.");
+          }
+          return errorResponse(res, 500, "ATTACHMENT_UPLOAD_FAILED", "Unable to upload Attachment.");
+        }
+      } catch {
+        return errorResponse(res, 500, "ATTACHMENT_UPLOAD_FAILED", "Unable to upload Attachment.");
+      }
+    },
+  );
+
+  app.get("/api/tickets/:ticketId/attachments", async (req: Request, res: Response) => {
+    const requesterId = parseRequesterId(req);
+    if (!requesterId) return errorResponse(res, 400, "REQUESTER_CONTEXT_INVALID", "A valid Development Requester is required.");
+    const ticketId = parsePositiveId(req.params.ticketId);
+    if (!ticketId) return errorResponse(res, 400, "INVALID_TICKET_ID", "Ticket ID must be a positive integer.");
+
+    try {
+      const requester = await prisma.requesterUser.findFirst({ where: { id: requesterId, isActive: true }, select: { id: true } });
+      if (!requester) return errorResponse(res, 400, "REQUESTER_CONTEXT_INVALID", "A valid Development Requester is required.");
+      const ownedTicket = await prisma.ticket.findFirst({ where: { id: ticketId, requesterId }, select: { id: true } });
+      if (!ownedTicket) return errorResponse(res, 404, "RESOURCE_NOT_FOUND", "Ticket not found.");
+      const attachments = await prisma.attachment.findMany({
+        where: { ticketId },
+        orderBy: [{ uploadedAt: "asc" }, { id: "asc" }],
+        select: { id: true, originalName: true, mimeType: true, sizeBytes: true, uploadedAt: true, removedAt: true, removedReason: true },
+      });
+      return res.status(200).json(attachments.map((attachment) => attachmentResponse(attachment, ticketId)));
+    } catch {
+      return errorResponse(res, 500, "ATTACHMENT_LIST_FAILED", "Unable to load Attachments.");
+    }
+  });
+
+  app.get("/api/tickets/:ticketId/attachments/:attachmentId/download", async (req: Request, res: Response) => {
+    const requesterId = parseRequesterId(req);
+    if (!requesterId) return errorResponse(res, 400, "REQUESTER_CONTEXT_INVALID", "A valid Development Requester is required.");
+    const ticketId = parsePositiveId(req.params.ticketId);
+    const attachmentId = parsePositiveId(req.params.attachmentId);
+    if (!ticketId) return errorResponse(res, 400, "INVALID_TICKET_ID", "Ticket ID must be a positive integer.");
+    if (!attachmentId) return errorResponse(res, 400, "INVALID_ATTACHMENT_ID", "Attachment ID must be a positive integer.");
+
+    try {
+      const requester = await prisma.requesterUser.findFirst({ where: { id: requesterId, isActive: true }, select: { id: true } });
+      if (!requester) return errorResponse(res, 400, "REQUESTER_CONTEXT_INVALID", "A valid Development Requester is required.");
+      const attachment = await prisma.attachment.findFirst({
+        where: { id: attachmentId, ticketId, removedAt: null, ticket: { requesterId } },
+        select: { id: true, originalName: true, mimeType: true, storageKey: true },
+      });
+      if (!attachment) return errorResponse(res, 404, "RESOURCE_NOT_FOUND", "Attachment not found.");
+      const bytes = await readFile(attachmentStoragePath(attachment.storageKey, attachment.originalName));
+      res.setHeader("Content-Type", attachment.mimeType);
+      res.setHeader("Content-Disposition", `attachment; filename*=UTF-8''${encodeURIComponent(sanitizeAttachmentName(attachment.originalName))}`);
+      res.setHeader("X-Content-Type-Options", "nosniff");
+      return res.status(200).send(bytes);
+    } catch {
+      return errorResponse(res, 500, "ATTACHMENT_DOWNLOAD_FAILED", "Unable to download Attachment.");
+    }
+  });
+
+  app.delete("/api/tickets/:ticketId/attachments/:attachmentId", async (req: Request, res: Response) => {
+    const requesterId = parseRequesterId(req);
+    if (!requesterId) return errorResponse(res, 400, "REQUESTER_CONTEXT_INVALID", "A valid Development Requester is required.");
+    const ticketId = parsePositiveId(req.params.ticketId);
+    const attachmentId = parsePositiveId(req.params.attachmentId);
+    if (!ticketId) return errorResponse(res, 400, "INVALID_TICKET_ID", "Ticket ID must be a positive integer.");
+    if (!attachmentId) return errorResponse(res, 400, "INVALID_ATTACHMENT_ID", "Attachment ID must be a positive integer.");
+    const reason = req.body && typeof req.body === "object" && !Array.isArray(req.body) && typeof req.body.reason === "string" ? req.body.reason.trim() : "";
+    if (reason.length < 5 || reason.length > 250) {
+      return errorResponse(res, 400, "VALIDATION_FAILED", "Please provide a removal reason between 5 and 250 characters.", { reason: ["Reason must contain 5 to 250 characters."] });
+    }
+
+    try {
+      const requester = await prisma.requesterUser.findFirst({ where: { id: requesterId, isActive: true }, select: { id: true } });
+      if (!requester) return errorResponse(res, 400, "REQUESTER_CONTEXT_INVALID", "A valid Development Requester is required.");
+      const removed = await prisma.$transaction(async (tx) => {
+        await tx.$queryRaw(Prisma.sql`SELECT "id" FROM "Ticket" WHERE "id" = ${ticketId} AND "requesterId" = ${requesterId} FOR UPDATE`);
+        const existing = await tx.attachment.findFirst({ where: { id: attachmentId, ticketId, removedAt: null, ticket: { requesterId } }, select: { id: true } });
+        if (!existing) throw new Error("RESOURCE_NOT_FOUND");
+        return tx.attachment.update({
+          where: { id: attachmentId },
+          data: { removedAt: new Date(), removedReason: reason, removedByRequesterId: requesterId },
+          select: { id: true, originalName: true, mimeType: true, sizeBytes: true, uploadedAt: true, removedAt: true, removedReason: true },
+        });
+      });
+      return res.status(200).json(attachmentResponse(removed, ticketId));
+    } catch (error) {
+      if (error instanceof Error && error.message === "RESOURCE_NOT_FOUND") return errorResponse(res, 404, "RESOURCE_NOT_FOUND", "Attachment not found.");
+      return errorResponse(res, 500, "ATTACHMENT_REMOVE_FAILED", "Unable to remove Attachment.");
     }
   });
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -57,7 +57,9 @@ const ticketListQueryFields = new Set([
 
 const MAX_ATTACHMENT_SIZE = 5_242_880;
 const MAX_ACTIVE_ATTACHMENTS = 5;
-const attachmentStorageDirectory = path.resolve(process.env.ATTACHMENT_STORAGE_DIR ?? path.join(process.cwd(), "storage", "attachments"));
+function attachmentStorageDirectory(): string {
+  return path.resolve(process.env.ATTACHMENT_STORAGE_DIR ?? path.join(process.cwd(), "storage", "attachments"));
+}
 const attachmentTypes = {
   ".jpg": { mimeType: "image/jpeg", extension: ".jpg" },
   ".jpeg": { mimeType: "image/jpeg", extension: ".jpeg" },
@@ -391,7 +393,8 @@ function sanitizeAttachmentName(originalName: string): string {
   const baseName = path.basename(originalName).replace(/[\u0000-\u001f\u007f]/g, "_").replace(/[<>:"/\\|?*]/g, "_").trim() || "attachment";
   const extension = path.extname(baseName);
   const stem = path.basename(baseName, extension);
-  return `${stem.slice(0, Math.max(1, 255 - extension.length))}${extension}`;
+  const maxStemCodePoints = Math.max(1, 255 - Array.from(extension).length);
+  return `${Array.from(stem).slice(0, maxStemCodePoints).join("")}${extension}`;
 }
 
 function hasMatchingSignature(buffer: Buffer, extension: keyof typeof attachmentTypes): boolean {
@@ -403,7 +406,7 @@ function hasMatchingSignature(buffer: Buffer, extension: keyof typeof attachment
 
 function attachmentStoragePath(storageKey: string, originalName: string): string {
   const extension = path.extname(originalName).toLowerCase();
-  return path.join(attachmentStorageDirectory, `${storageKey}${extension}`);
+  return path.join(attachmentStorageDirectory(), `${storageKey}${extension}`);
 }
 
 function isIdempotencyUniqueViolation(error: unknown): error is Prisma.PrismaClientKnownRequestError {
@@ -659,12 +662,12 @@ export function createApp(prisma: ReferenceDataPrisma = getPrisma()): express.Ex
         const originalName = sanitizeAttachmentName(req.file.originalname);
         const storagePath = attachmentStoragePath(storageKey, originalName);
         try {
-          await mkdir(attachmentStorageDirectory, { recursive: true });
-          await writeFile(storagePath, req.file.buffer, { flag: "wx" });
           const created = await prisma.$transaction(async (tx) => {
             await tx.$queryRaw(Prisma.sql`SELECT "id" FROM "Ticket" WHERE "id" = ${ticketId} FOR UPDATE`);
             const activeCount = await tx.attachment.count({ where: { ticketId, removedAt: null } });
             if (activeCount >= MAX_ACTIVE_ATTACHMENTS) throw new Error("ATTACHMENT_LIMIT_REACHED");
+            await mkdir(attachmentStorageDirectory(), { recursive: true });
+            await writeFile(storagePath, req.file!.buffer, { flag: "wx" });
             return tx.attachment.create({
               data: {
                 ticketId,

--- a/server/tests/lab-02/attachments.api.test.ts
+++ b/server/tests/lab-02/attachments.api.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+import { randomUUID } from "node:crypto";
+import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { createApp, type ReferenceDataPrisma } from "../../src/app.js";
+
+const storageDirectory = path.resolve(process.cwd(), "storage", "attachments");
+const pdfBytes = Buffer.from("%PDF-1.7\nfixture");
+
+function makeAttachment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 12,
+    originalName: "report.pdf",
+    mimeType: "application/pdf",
+    sizeBytes: pdfBytes.length,
+    uploadedAt: new Date("2026-08-24T10:02:00.000Z"),
+    removedAt: null,
+    removedReason: null,
+    storageKey: randomUUID(),
+    ...overrides,
+  };
+}
+
+function makePrisma(options: {
+  attachment?: unknown;
+  attachments?: unknown[];
+  activeCount?: number;
+  inactiveRequester?: boolean;
+  missingTicket?: boolean;
+  fail?: boolean;
+  failTransaction?: boolean;
+} = {}) {
+  const attachmentResult = Object.prototype.hasOwnProperty.call(options, "attachment") ? options.attachment : makeAttachment();
+  const transaction = {
+    attachment: {
+      count: vi.fn().mockResolvedValue(options.activeCount ?? 0),
+      create: vi.fn().mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+        ...makeAttachment(),
+        ...data,
+        id: 12,
+        uploadedAt: new Date("2026-08-24T10:02:00.000Z"),
+        removedAt: null,
+        removedReason: null,
+      })),
+      findFirst: vi.fn().mockResolvedValue(attachmentResult),
+      update: vi.fn().mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+        ...makeAttachment({ removedAt: new Date("2026-08-25T10:00:00.000Z"), removedReason: "No longer needed" }),
+        ...data,
+      })),
+      findMany: vi.fn().mockResolvedValue(options.attachments ?? [makeAttachment()]),
+    },
+    $queryRaw: vi.fn().mockResolvedValue([]),
+    requesterUser: {
+      findFirst: vi.fn().mockResolvedValue(options.inactiveRequester ? null : { id: 1 }),
+    },
+    ticket: {
+      findFirst: options.fail ? vi.fn().mockRejectedValue(new Error("database unavailable")) : vi.fn().mockResolvedValue(options.missingTicket ? null : { id: 42 }),
+    },
+  };
+  const prisma = {
+    ...transaction,
+    $transaction: vi.fn(async (callback: (tx: typeof transaction) => unknown) => {
+      if (options.failTransaction) throw new Error("database unavailable");
+      return callback(transaction);
+    }),
+  } as unknown as ReferenceDataPrisma;
+  return { prisma, transaction };
+}
+
+afterEach(async () => {
+  await rm(storageDirectory, { recursive: true, force: true });
+});
+
+describe("Attachment APIs", () => {
+  it("uploads one supported file and returns active metadata", async () => {
+    const { prisma, transaction } = makePrisma();
+    const res = await request(createApp(prisma))
+      .post("/api/tickets/42/attachments")
+      .set("X-Requester-Id", "1")
+      .attach("file", pdfBytes, "../battery report.pdf");
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      id: 12,
+      originalName: "battery report.pdf",
+      mimeType: "application/pdf",
+      state: "ACTIVE",
+      removedAt: null,
+      removedReason: null,
+      downloadUrl: "/api/tickets/42/attachments/12/download",
+    });
+    expect(res.body.storageKey).toBeUndefined();
+    expect(transaction.attachment.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ ticketId: 42, originalName: "battery report.pdf", mimeType: "application/pdf" }),
+    }));
+    expect((await readdir(storageDirectory)).length).toBe(1);
+  });
+
+  it("accepts the exact 5 MiB boundary", async () => {
+    const { prisma } = makePrisma();
+    const exactLimit = Buffer.concat([Buffer.from("%PDF-1.7\n"), Buffer.alloc(5_242_880 - 9)]);
+    const res = await request(createApp(prisma))
+      .post("/api/tickets/42/attachments")
+      .set("X-Requester-Id", "1")
+      .attach("file", exactLimit, "exact-limit.pdf");
+
+    expect(res.status).toBe(201);
+    expect(res.body.sizeBytes).toBe(5_242_880);
+  });
+
+  it("rejects missing, unsupported, signature-mismatched, oversized, and sixth active files", async () => {
+    const missing = await request(createApp(makePrisma().prisma)).post("/api/tickets/42/attachments").set("X-Requester-Id", "1");
+    expect(missing.status).toBe(400);
+    expect(missing.body.error.code).toBe("ATTACHMENT_REQUIRED");
+
+    const unsupported = await request(createApp(makePrisma().prisma))
+      .post("/api/tickets/42/attachments")
+      .set("X-Requester-Id", "1")
+      .attach("file", Buffer.from("plain text"), "notes.txt");
+    expect(unsupported.status).toBe(415);
+    expect(unsupported.body.error.code).toBe("ATTACHMENT_TYPE_UNSUPPORTED");
+
+    const mismatch = await request(createApp(makePrisma().prisma))
+      .post("/api/tickets/42/attachments")
+      .set("X-Requester-Id", "1")
+      .attach("file", Buffer.from("plain text"), "notes.pdf");
+    expect(mismatch.status).toBe(415);
+
+    const oversized = await request(createApp(makePrisma().prisma))
+      .post("/api/tickets/42/attachments")
+      .set("X-Requester-Id", "1")
+      .attach("file", Buffer.alloc(5_242_881), "large.pdf");
+    expect(oversized.status).toBe(413);
+    expect(oversized.body.error.code).toBe("ATTACHMENT_TOO_LARGE");
+
+    const limited = await request(createApp(makePrisma({ activeCount: 5 }).prisma))
+      .post("/api/tickets/42/attachments")
+      .set("X-Requester-Id", "1")
+      .attach("file", pdfBytes, "limited.pdf");
+    expect(limited.status).toBe(409);
+    expect(limited.body.error.code).toBe("ATTACHMENT_LIMIT_REACHED");
+  });
+
+  it("lists owned active and removed Attachment metadata in deterministic order", async () => {
+    const attachments = [
+      makeAttachment({ id: 10, originalName: "first.pdf", uploadedAt: new Date("2026-08-24T10:00:00.000Z") }),
+      makeAttachment({ id: 11, originalName: "removed.pdf", uploadedAt: new Date("2026-08-24T10:00:00.000Z"), removedAt: new Date("2026-08-25T10:00:00.000Z"), removedReason: "Duplicate" }),
+    ];
+    const { prisma, transaction } = makePrisma({ attachments });
+    const res = await request(createApp(prisma)).get("/api/tickets/42/attachments").set("X-Requester-Id", "1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.map((item: { originalName: string }) => item.originalName)).toEqual(["first.pdf", "removed.pdf"]);
+    expect(res.body[0]).toMatchObject({ state: "ACTIVE", downloadUrl: "/api/tickets/42/attachments/10/download" });
+    expect(res.body[1]).toMatchObject({ state: "REMOVED", downloadUrl: null, removedReason: "Duplicate" });
+    expect(transaction.attachment.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { ticketId: 42 },
+      orderBy: [{ uploadedAt: "asc" }, { id: "asc" }],
+    }));
+  });
+
+  it("returns safe list errors and does not expose non-owned Tickets", async () => {
+    const missing = await request(createApp(makePrisma({ missingTicket: true }).prisma))
+      .get("/api/tickets/42/attachments")
+      .set("X-Requester-Id", "1");
+    expect(missing.status).toBe(404);
+    expect(missing.body.error.code).toBe("RESOURCE_NOT_FOUND");
+
+    const failed = await request(createApp(makePrisma({ fail: true }).prisma))
+      .get("/api/tickets/42/attachments")
+      .set("X-Requester-Id", "1");
+    expect(failed.status).toBe(500);
+    expect(failed.body.error.code).toBe("ATTACHMENT_LIST_FAILED");
+  });
+
+  it("downloads only active owned files with safe headers", async () => {
+    const attachment = makeAttachment({ originalName: "résumé.pdf", storageKey: randomUUID() });
+    await mkdir(storageDirectory, { recursive: true });
+    await writeFile(path.join(storageDirectory, `${attachment.storageKey}.pdf`), pdfBytes);
+    const { prisma, transaction } = makePrisma({ attachment });
+    const res = await request(createApp(prisma)).get("/api/tickets/42/attachments/12/download").set("X-Requester-Id", "1");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("application/pdf");
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+    expect(res.headers["content-disposition"]).toContain("filename*=UTF-8''r%C3%A9sum%C3%A9.pdf");
+    expect(Buffer.from(res.body).equals(pdfBytes)).toBe(true);
+    expect(transaction.attachment.findFirst).toHaveBeenCalledWith(expect.objectContaining({ where: { id: 12, ticketId: 42, removedAt: null, ticket: { requesterId: 1 } } }));
+  });
+
+  it("rejects removed or unavailable downloads safely", async () => {
+    const removed = await request(createApp(makePrisma({ attachment: null }).prisma))
+      .get("/api/tickets/42/attachments/12/download")
+      .set("X-Requester-Id", "1");
+    expect(removed.status).toBe(404);
+
+    const unavailable = await request(createApp(makePrisma().prisma))
+      .get("/api/tickets/42/attachments/12/download")
+      .set("X-Requester-Id", "1");
+    expect(unavailable.status).toBe(500);
+    expect(unavailable.body.error.code).toBe("ATTACHMENT_DOWNLOAD_FAILED");
+  });
+
+  it("soft-removes an active owned Attachment and validates the reason", async () => {
+    const { prisma, transaction } = makePrisma();
+    const res = await request(createApp(prisma))
+      .delete("/api/tickets/42/attachments/12")
+      .set("X-Requester-Id", "1")
+      .send({ reason: "No longer needed" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ state: "REMOVED", removedReason: "No longer needed", downloadUrl: null });
+    expect(transaction.attachment.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 12 },
+      data: expect.objectContaining({ removedReason: "No longer needed", removedByRequesterId: 1 }),
+    }));
+
+    const invalid = await request(createApp(makePrisma().prisma))
+      .delete("/api/tickets/42/attachments/12")
+      .set("X-Requester-Id", "1")
+      .send({ reason: "bad" });
+    expect(invalid.status).toBe(400);
+    expect(invalid.body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("accepts exact removal-reason boundaries and rejects an already removed file", async () => {
+    const minimum = await request(createApp(makePrisma().prisma))
+      .delete("/api/tickets/42/attachments/12")
+      .set("X-Requester-Id", "1")
+      .send({ reason: "12345" });
+    expect(minimum.status).toBe(200);
+
+    const maximum = await request(createApp(makePrisma().prisma))
+      .delete("/api/tickets/42/attachments/12")
+      .set("X-Requester-Id", "1")
+      .send({ reason: "r".repeat(250) });
+    expect(maximum.status).toBe(200);
+
+    const alreadyRemoved = await request(createApp(makePrisma({ attachment: null }).prisma))
+      .delete("/api/tickets/42/attachments/12")
+      .set("X-Requester-Id", "1")
+      .send({ reason: "No longer needed" });
+    expect(alreadyRemoved.status).toBe(404);
+  });
+
+  it("removes a written file when metadata transaction fails", async () => {
+    const res = await request(createApp(makePrisma({ failTransaction: true }).prisma))
+      .post("/api/tickets/42/attachments")
+      .set("X-Requester-Id", "1")
+      .attach("file", pdfBytes, "failed.pdf");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("ATTACHMENT_UPLOAD_FAILED");
+    expect(await readdir(storageDirectory)).toEqual([]);
+  });
+
+  it("rejects unknown or inactive Requesters before Ticket/Attachment access", async () => {
+    const unknown = makePrisma();
+    vi.mocked(unknown.prisma.requesterUser.findFirst).mockResolvedValue(null);
+    const unknownResponse = await request(createApp(unknown.prisma)).get("/api/tickets/42/attachments").set("X-Requester-Id", "999");
+    expect(unknownResponse.status).toBe(400);
+    expect(unknown.transaction.ticket.findFirst).not.toHaveBeenCalled();
+    expect(unknown.transaction.attachment.findMany).not.toHaveBeenCalled();
+
+    const inactive = makePrisma({ inactiveRequester: true });
+    const inactiveResponse = await request(createApp(inactive.prisma)).get("/api/tickets/42/attachments").set("X-Requester-Id", "1");
+    expect(inactiveResponse.status).toBe(400);
+    expect(inactive.transaction.ticket.findFirst).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/lab-02/attachments.api.test.ts
+++ b/server/tests/lab-02/attachments.api.test.ts
@@ -7,6 +7,13 @@ import { createApp, type ReferenceDataPrisma } from "../../src/app.js";
 
 const storageDirectory = path.resolve(process.cwd(), "storage", "attachments");
 const pdfBytes = Buffer.from("%PDF-1.7\nfixture");
+const validFixtures = [
+  { extension: "jpg", mimeType: "image/jpeg", bytes: Buffer.from([0xff, 0xd8, 0xff, 0xd9]) },
+  { extension: "jpeg", mimeType: "image/jpeg", bytes: Buffer.from([0xff, 0xd8, 0xff, 0xd9]) },
+  { extension: "png", mimeType: "image/png", bytes: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]) },
+  { extension: "webp", mimeType: "image/webp", bytes: Buffer.concat([Buffer.from("RIFF"), Buffer.alloc(4), Buffer.from("WEBP")]) },
+  { extension: "pdf", mimeType: "application/pdf", bytes: pdfBytes },
+] as const;
 
 function makeAttachment(overrides: Record<string, unknown> = {}) {
   return {
@@ -73,6 +80,18 @@ afterEach(async () => {
 });
 
 describe("Attachment APIs", () => {
+  it.each(validFixtures)("accepts .$extension with matching MIME and signature", async ({ extension, mimeType, bytes }) => {
+    const { prisma } = makePrisma();
+    const res = await request(createApp(prisma))
+      .post("/api/tickets/42/attachments")
+      .set("X-Requester-Id", "1")
+      .attach("file", bytes, { filename: `valid.${extension}`, contentType: mimeType });
+
+    expect(res.status).toBe(201);
+    expect(res.body.mimeType).toBe(mimeType);
+    expect(res.body.originalName).toBe(`valid.${extension}`);
+  });
+
   it("uploads one supported file and returns active metadata", async () => {
     const { prisma, transaction } = makePrisma();
     const res = await request(createApp(prisma))
@@ -126,6 +145,12 @@ describe("Attachment APIs", () => {
       .set("X-Requester-Id", "1")
       .attach("file", Buffer.from("plain text"), "notes.pdf");
     expect(mismatch.status).toBe(415);
+
+    const mimeMismatch = await request(createApp(makePrisma().prisma))
+      .post("/api/tickets/42/attachments")
+      .set("X-Requester-Id", "1")
+      .attach("file", validFixtures[2].bytes, { filename: "image.png", contentType: "image/jpeg" });
+    expect(mimeMismatch.status).toBe(415);
 
     const oversized = await request(createApp(makePrisma().prisma))
       .post("/api/tickets/42/attachments")
@@ -252,7 +277,7 @@ describe("Attachment APIs", () => {
 
     expect(res.status).toBe(500);
     expect(res.body.error.code).toBe("ATTACHMENT_UPLOAD_FAILED");
-    expect(await readdir(storageDirectory)).toEqual([]);
+    expect(await readdir(storageDirectory).catch(() => [])).toEqual([]);
   });
 
   it("rejects unknown or inactive Requesters before Ticket/Attachment access", async () => {
@@ -267,5 +292,25 @@ describe("Attachment APIs", () => {
     const inactiveResponse = await request(createApp(inactive.prisma)).get("/api/tickets/42/attachments").set("X-Requester-Id", "1");
     expect(inactiveResponse.status).toBe(400);
     expect(inactive.transaction.ticket.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("sanitizes unsafe names and truncates Unicode names without splitting emoji", async () => {
+    const { prisma } = makePrisma();
+    const unsafe = await request(createApp(prisma))
+      .post("/api/tickets/42/attachments")
+      .set("X-Requester-Id", "1")
+      .attach("file", pdfBytes, "../bad\nname.pdf");
+    expect(unsafe.status).toBe(201);
+    expect(unsafe.body.originalName).toBe("bad_name.pdf");
+
+    const longName = `${"😀".repeat(300)}.pdf`;
+    const unicode = await request(createApp(makePrisma().prisma))
+      .post("/api/tickets/42/attachments")
+      .set("X-Requester-Id", "1")
+      .attach("file", pdfBytes, longName);
+    expect(unicode.status).toBe(201);
+    expect(Array.from(unicode.body.originalName).length).toBe(255);
+    expect(unicode.body.originalName.endsWith(".pdf")).toBe(true);
+    expect(unicode.body.originalName).not.toMatch(/[\ud800-\udfff](?![\udc00-\udfff])/);
   });
 });

--- a/server/tests/lab-02/attachments.postgres.integration.test.ts
+++ b/server/tests/lab-02/attachments.postgres.integration.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import request from "supertest";
+import { randomUUID } from "node:crypto";
+import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { Prisma, PrismaClient } from "@prisma/client";
+import { createApp } from "../../src/app.js";
+
+const runIntegration = process.env.RUN_DB_INTEGRATION === "1" && Boolean(process.env.DATABASE_URL);
+const integration = runIntegration ? describe : describe.skip;
+const storageDirectory = path.resolve(process.cwd(), "storage", "attachments-integration");
+const pdfBytes = Buffer.from("%PDF-1.7\npostgres integration fixture");
+
+integration("Attachment APIs PostgreSQL integration", () => {
+  let prisma: PrismaClient;
+  let requesterA: number;
+  let requesterB: number;
+  let categoryId: number;
+  let relatedSystemId: number;
+  const ticketIds: number[] = [];
+
+  async function createTicket(requesterId: number, summary: string) {
+    const [{ nextval }] = await prisma.$queryRaw<Array<{ nextval: bigint }>>(
+      Prisma.sql`SELECT nextval('"TicketNumberSequence"')`,
+    );
+    const ticket = await prisma.ticket.create({
+      data: {
+        ticketNumber: `TKT-${new Date().getUTCFullYear()}-${nextval.toString().padStart(6, "0")}`,
+        requesterId,
+        categoryId,
+        relatedSystemId,
+        summary,
+        description: "Attachment API PostgreSQL integration fixture.",
+        requestedPriority: "MEDIUM",
+        currentStatus: "NEW",
+        clientRequestId: randomUUID(),
+        requestPayloadHash: "b".repeat(64),
+      },
+    });
+    ticketIds.push(ticket.id);
+    return ticket.id;
+  }
+
+  beforeAll(async () => {
+    process.env.ATTACHMENT_STORAGE_DIR = storageDirectory;
+    await rm(storageDirectory, { recursive: true, force: true });
+    prisma = new PrismaClient();
+    await prisma.$connect();
+    const [requesters, category, relatedSystem] = await Promise.all([
+      prisma.requesterUser.findMany({ where: { isActive: true }, select: { id: true }, orderBy: { id: "asc" }, take: 2 }),
+      prisma.category.findFirst({ where: { isActive: true }, select: { id: true } }),
+      prisma.relatedSystem.findFirst({ where: { isActive: true }, select: { id: true } }),
+    ]);
+    if (requesters.length < 2 || !category || !relatedSystem) {
+      throw new Error("Integration test requires two active Requesters and seeded reference data.");
+    }
+    requesterA = requesters[0].id;
+    requesterB = requesters[1].id;
+    categoryId = category.id;
+    relatedSystemId = relatedSystem.id;
+  });
+
+  afterAll(async () => {
+    if (prisma) {
+      if (ticketIds.length > 0) await prisma.ticket.deleteMany({ where: { id: { in: ticketIds } } });
+      await prisma.$disconnect();
+    }
+    await rm(storageDirectory, { recursive: true, force: true });
+    delete process.env.ATTACHMENT_STORAGE_DIR;
+  });
+
+  it("persists real metadata, enforces ownership, downloads, and soft-removes", async () => {
+    const ticketId = await createTicket(requesterA, "Attachment lifecycle integration");
+    const app = createApp(prisma);
+    const uploaded = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set("X-Requester-Id", String(requesterA))
+      .attach("file", pdfBytes, "lifecycle.pdf");
+    expect(uploaded.status).toBe(201);
+
+    const attachmentId = uploaded.body.id as number;
+    const stored = await prisma.attachment.findUnique({ where: { id: attachmentId } });
+    expect(stored).toMatchObject({ ticketId, originalName: "lifecycle.pdf", mimeType: "application/pdf", removedAt: null });
+
+    const listed = await request(app).get(`/api/tickets/${ticketId}/attachments`).set("X-Requester-Id", String(requesterA));
+    expect(listed.status).toBe(200);
+    expect(listed.body).toHaveLength(1);
+    expect(listed.body[0]).toMatchObject({ id: attachmentId, state: "ACTIVE", downloadUrl: `/api/tickets/${ticketId}/attachments/${attachmentId}/download` });
+
+    const downloaded = await request(app).get(`/api/tickets/${ticketId}/attachments/${attachmentId}/download`).set("X-Requester-Id", String(requesterA));
+    expect(downloaded.status).toBe(200);
+    expect(Buffer.from(downloaded.body).equals(pdfBytes)).toBe(true);
+    expect(downloaded.headers["x-content-type-options"]).toBe("nosniff");
+
+    const nonOwner = await request(app).get(`/api/tickets/${ticketId}/attachments`).set("X-Requester-Id", String(requesterB));
+    expect(nonOwner.status).toBe(404);
+
+    const removed = await request(app)
+      .delete(`/api/tickets/${ticketId}/attachments/${attachmentId}`)
+      .set("X-Requester-Id", String(requesterA))
+      .send({ reason: "No longer required" });
+    expect(removed.status).toBe(200);
+    expect(removed.body).toMatchObject({ state: "REMOVED", downloadUrl: null, removedReason: "No longer required" });
+    await expect(prisma.attachment.findUnique({ where: { id: attachmentId } })).resolves.toMatchObject({ removedAt: expect.any(Date), removedReason: "No longer required" });
+
+    const removedDownload = await request(app).get(`/api/tickets/${ticketId}/attachments/${attachmentId}/download`).set("X-Requester-Id", String(requesterA));
+    expect(removedDownload.status).toBe(404);
+  });
+
+  it("serializes concurrent uploads at the five-active limit without orphan files", async () => {
+    const ticketId = await createTicket(requesterA, "Attachment concurrency integration");
+    await rm(storageDirectory, { recursive: true, force: true });
+    await mkdir(storageDirectory, { recursive: true });
+    const existingKeys = Array.from({ length: 4 }, (_, index) => `00000000-0000-4000-8000-${String(index + 1).padStart(12, "0")}`);
+    await prisma.attachment.createMany({
+      data: existingKeys.map((storageKey, index) => ({
+        ticketId,
+        originalName: `existing-${index}.pdf`,
+        storageKey,
+        mimeType: "application/pdf",
+        sizeBytes: pdfBytes.length,
+      })),
+    });
+    await Promise.all(existingKeys.map((storageKey) => writeFile(path.join(storageDirectory, `${storageKey}.pdf`), pdfBytes)));
+
+    const app = createApp(prisma);
+    const results = await Promise.all([
+      request(app).post(`/api/tickets/${ticketId}/attachments`).set("X-Requester-Id", String(requesterA)).attach("file", pdfBytes, "race-a.pdf"),
+      request(app).post(`/api/tickets/${ticketId}/attachments`).set("X-Requester-Id", String(requesterA)).attach("file", pdfBytes, "race-b.pdf"),
+    ]);
+    expect(results.map((result) => result.status).sort()).toEqual([201, 409]);
+    await expect(prisma.attachment.count({ where: { ticketId, removedAt: null } })).resolves.toBe(5);
+    expect(await readdir(storageDirectory)).toHaveLength(5);
+  });
+});

--- a/server/tests/lab-02/attachments.postgres.integration.test.ts
+++ b/server/tests/lab-02/attachments.postgres.integration.test.ts
@@ -107,6 +107,27 @@ integration("Attachment APIs PostgreSQL integration", () => {
     expect(removedDownload.status).toBe(404);
   });
 
+  it("does not leave metadata when storage preparation fails", async () => {
+    const ticketId = await createTicket(requesterA, "Attachment storage rollback integration");
+    const failurePath = path.resolve(process.cwd(), "storage", "attachment-storage-failure-marker");
+    await rm(failurePath, { recursive: true, force: true });
+    await mkdir(path.dirname(failurePath), { recursive: true });
+    await writeFile(failurePath, "not a directory");
+    const before = await prisma.attachment.count({ where: { ticketId } });
+    process.env.ATTACHMENT_STORAGE_DIR = failurePath;
+
+    const response = await request(createApp(prisma))
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set("X-Requester-Id", String(requesterA))
+      .attach("file", pdfBytes, "storage-failure.pdf");
+
+    expect(response.status).toBe(500);
+    expect(response.body.error.code).toBe("ATTACHMENT_UPLOAD_FAILED");
+    await expect(prisma.attachment.count({ where: { ticketId } })).resolves.toBe(before);
+    process.env.ATTACHMENT_STORAGE_DIR = storageDirectory;
+    await rm(failurePath, { force: true });
+  });
+
   it("serializes concurrent uploads at the five-active limit without orphan files", async () => {
     const ticketId = await createTicket(requesterA, "Attachment concurrency integration");
     await rm(storageDirectory, { recursive: true, force: true });


### PR DESCRIPTION
## Related Issue

Closes #24

## Summary

This Pull Request implements the Lab 2 Attachment lifecycle APIs.

## Changes

- Added Attachment upload using multipart form data
- Added extension, MIME, and file-signature validation
- Added 5 MiB size limit
- Added maximum five active Attachments per Ticket
- Added storage outside the public web root
- Added orphan-file cleanup on database failure
- Added Attachment metadata listing
- Added ownership-protected download
- Added soft removal with validated reason
- Added active Requester and ownership validation
- Added automated API tests

## Verification

- `npm test`
- `npm run build`

All 53 tests pass.

## Out of Scope

- UI implementation
- Authentication
- Malware scanning
- Cloud storage