### PR TITLE
Feature 13: Implement Create Ticket UI

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -43,9 +43,26 @@ nav a { color: white; text-decoration: none; font-weight: 600; }
 nav a:hover { text-decoration: underline; }
 .nav-unavailable { border: 0; padding: 0; background: transparent; color: rgb(255 255 255 / 70%); font: inherit; font-weight: 600; cursor: not-allowed; }
 .nav-unavailable span { font-size: 12px; font-weight: 500; }
+.nav-create { border: 0; padding: 0; background: transparent; color: white; font: inherit; font-weight: 600; cursor: pointer; }
+.nav-create.active, .nav-create:hover { text-decoration: underline; }
 .requester-context { display: flex; align-items: center; gap: 12px; margin-left: auto; font-size: 14px; }
 .change-requester { border: 1px solid rgb(255 255 255 / 75%); border-radius: 6px; padding: 6px 10px; background: transparent; color: white; cursor: pointer; }
 .shell-content { width: min(100% - 32px, 1120px); margin: 0 auto; padding: 48px 0; }
 .shell-content p:not(.eyebrow) { max-width: 640px; color: var(--color-text-muted); }
 .context-card { width: min(100%, 560px); margin-top: 24px; padding: 20px; border: 1px solid var(--color-border); border-radius: 10px; background: white; }
+.back-button { border: 0; padding: 0; background: transparent; color: var(--color-green-secondary); font-weight: 700; cursor: pointer; }
+.ticket-form { max-width: 900px; padding: 24px; border: 1px solid var(--color-border); border-radius: 12px; background: white; }
+.readonly-grid, .form-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-bottom: 20px; }
+.ticket-form label { color: var(--color-text); }
+.ticket-form input, .ticket-form textarea, .ticket-form select { display: block; width: 100%; margin-top: 6px; padding: 9px 12px; border: 1px solid var(--color-border); border-radius: 8px; background: white; color: var(--color-text); }
+.ticket-form input[readonly] { background: #eff3f0; color: var(--color-text-muted); }
+.ticket-form textarea { min-height: 150px; resize: vertical; }
+.ticket-form small { display: block; margin-top: 5px; color: var(--color-text-muted); font-size: 13px; font-weight: 400; }
+.field-error { color: var(--color-error) !important; }
+.file-list { margin: -8px 0 20px; padding: 12px 12px 12px 28px; border: 1px solid var(--color-border); border-radius: 8px; background: var(--color-page); }
+.form-actions { display: flex; justify-content: flex-end; gap: 12px; margin-top: 24px; }
+.form-actions .button-primary { width: auto; margin-top: 0; }
+.form-actions .button-secondary { min-width: 100px; }
+.submit-button { min-width: 150px; }
 @media (max-width: 700px) { .selector-card { padding: 24px 20px; } .header-inner { align-items: flex-start; flex-direction: column; gap: 12px; } .requester-context { margin-left: 0; flex-wrap: wrap; } nav { width: 100%; } }
+@media (max-width: 760px) { .readonly-grid, .form-grid { grid-template-columns: 1fr; } .ticket-form { padding: 18px; } .form-actions { flex-direction: column-reverse; } .form-actions button { width: 100% !important; } }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -60,6 +60,7 @@ nav a:hover { text-decoration: underline; }
 .ticket-form small { display: block; margin-top: 5px; color: var(--color-text-muted); font-size: 13px; font-weight: 400; }
 .field-error { color: var(--color-error) !important; }
 .file-list { margin: -8px 0 20px; padding: 12px 12px 12px 28px; border: 1px solid var(--color-border); border-radius: 8px; background: var(--color-page); }
+.file-remove, .file-retry { margin-left: 12px; padding: 4px 8px; font-size: 0.875rem; }
 .form-actions { display: flex; justify-content: flex-end; gap: 12px; margin-top: 24px; }
 .form-actions .button-primary { width: auto; margin-top: 0; }
 .form-actions .button-secondary { min-width: 100px; }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,7 +6,14 @@ const REQUESTER_STORAGE_KEY = "toktickit.requesterId";
 type RequesterLoadState = "loading" | "ready" | "empty" | "error";
 
 function createClientRequestId() {
-  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
+  const bytes = new Uint8Array(16);
+  if (globalThis.crypto?.getRandomValues) globalThis.crypto.getRandomValues(bytes);
+  else bytes.forEach((_, index) => { bytes[index] = Math.floor(Math.random() * 256); });
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (value) => value.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
 function RequesterSelector({
@@ -68,6 +75,7 @@ function RequesterSelector({
 type CreateScreenProps = { requester: DevelopmentRequester; onBack: () => void };
 type AttachmentStatus = "pending" | "invalid" | "uploading" | "uploaded" | "failed";
 type SelectedFile = { id: string; file: File; status: AttachmentStatus; error?: string; message?: string };
+const EMPTY_TICKET_FORM = { categoryId: "", relatedSystemId: "", requestedPriority: "MEDIUM", summary: "", description: "" };
 
 function CreateTicketScreen({ requester, onBack }: CreateScreenProps) {
   const [categories, setCategories] = useState<ReferenceItem[]>([]);
@@ -75,13 +83,13 @@ function CreateTicketScreen({ requester, onBack }: CreateScreenProps) {
   const [referenceState, setReferenceState] = useState<"loading" | "ready" | "error">("loading");
   const [referenceError, setReferenceError] = useState<string | null>(null);
   const [referenceRetryToken, setReferenceRetryToken] = useState(0);
-  const [form, setForm] = useState({ categoryId: "", relatedSystemId: "", requestedPriority: "MEDIUM", summary: "", description: "" });
+  const [form, setForm] = useState(EMPTY_TICKET_FORM);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [files, setFiles] = useState<SelectedFile[]>([]);
   const [submitState, setSubmitState] = useState<"idle" | "submitting" | "success" | "error">("idle");
   const [ticket, setTicket] = useState<CreatedTicket | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
-  const clientRequestId = useState(createClientRequestId)[0];
+  const [clientRequestId, setClientRequestId] = useState(() => createClientRequestId());
   const fileId = useRef(0);
 
   useEffect(() => {
@@ -103,9 +111,10 @@ function CreateTicketScreen({ requester, onBack }: CreateScreenProps) {
       let validCount = current.filter((item) => item.status !== "invalid").length;
       const additions = selected.map((file) => {
         const extension = file.name.toLowerCase().split(".").pop();
-        const validType = ["jpg", "jpeg", "png", "webp", "pdf"].includes(extension ?? "");
+        const expectedMime = extension === "jpg" || extension === "jpeg" ? "image/jpeg" : extension === "png" ? "image/png" : extension === "webp" ? "image/webp" : extension === "pdf" ? "application/pdf" : null;
         let error: string | undefined;
-        if (!validType) error = "Unsupported file type.";
+        if (!expectedMime) error = "Unsupported file type.";
+        else if (file.type !== expectedMime) error = `MIME type must be ${expectedMime}.`;
         else if (file.size > 5_242_880) error = "File exceeds 5 MiB.";
         else if (validCount >= 5) error = "Maximum five valid files can be uploaded.";
         else validCount += 1;
@@ -118,6 +127,16 @@ function CreateTicketScreen({ requester, onBack }: CreateScreenProps) {
 
   function removeSelectedFile(index: number) {
     setFiles((current) => current.filter((_, fileIndex) => fileIndex !== index));
+  }
+
+  function startNewTicket() {
+    setForm(EMPTY_TICKET_FORM);
+    setFieldErrors({});
+    setFiles([]);
+    setTicket(null);
+    setSubmitError(null);
+    setSubmitState("idle");
+    setClientRequestId(createClientRequestId());
   }
 
   function validateForm() {
@@ -177,7 +196,7 @@ function CreateTicketScreen({ requester, onBack }: CreateScreenProps) {
     <main className="shell-content" id="create-ticket">
       <div className="alert alert-success" role="status"><h1>Ticket created</h1><p>Official Ticket Number: <strong>{ticket.ticketNumber}</strong></p></div>
       {files.length > 0 && <section className="context-card"><h2>Attachment results</h2><ul>{files.map((selected) => <li key={selected.id}>{selected.file.name}: {selected.status === "uploaded" ? "Uploaded" : selected.status === "invalid" ? selected.error : selected.status === "uploading" ? "Uploading…" : selected.message}{selected.status === "failed" && <button className="button button-secondary file-retry" type="button" onClick={() => retryAttachment(selected.id)}>Retry</button>}</li>)}</ul></section>}
-      <button className="button button-secondary" onClick={onBack}>Back to workspace</button>
+      <div className="form-actions"><button className="button button-secondary" onClick={onBack}>Back to workspace</button><button className="button button-primary" onClick={startNewTicket}>Create another Ticket</button></div>
     </main>
   );
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,9 +1,13 @@
-import { useEffect, useState, type ChangeEvent, type FormEvent } from "react";
+import { useEffect, useRef, useState, type ChangeEvent, type FormEvent } from "react";
 import { createTicket, CreatedTicket, DevelopmentRequester, getCategories, getDevelopmentRequesters, getRelatedSystems, ReferenceItem, uploadTicketAttachment } from "./api.js";
 import "./App.css";
 
 const REQUESTER_STORAGE_KEY = "toktickit.requesterId";
 type RequesterLoadState = "loading" | "ready" | "empty" | "error";
+
+function createClientRequestId() {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
 
 function RequesterSelector({
   requesters,
@@ -62,7 +66,8 @@ function RequesterSelector({
 }
 
 type CreateScreenProps = { requester: DevelopmentRequester; onBack: () => void };
-type SelectedFile = { file: File; error?: string };
+type AttachmentStatus = "pending" | "invalid" | "uploading" | "uploaded" | "failed";
+type SelectedFile = { id: string; file: File; status: AttachmentStatus; error?: string; message?: string };
 
 function CreateTicketScreen({ requester, onBack }: CreateScreenProps) {
   const [categories, setCategories] = useState<ReferenceItem[]>([]);
@@ -75,10 +80,9 @@ function CreateTicketScreen({ requester, onBack }: CreateScreenProps) {
   const [files, setFiles] = useState<SelectedFile[]>([]);
   const [submitState, setSubmitState] = useState<"idle" | "submitting" | "success" | "error">("idle");
   const [ticket, setTicket] = useState<CreatedTicket | null>(null);
-  const [attachmentResults, setAttachmentResults] = useState<{ name: string; ok: boolean; message?: string }[]>([]);
-  const [failedUploadFiles, setFailedUploadFiles] = useState<File[]>([]);
-  const [retryingAttachments, setRetryingAttachments] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const clientRequestId = useState(createClientRequestId)[0];
+  const fileId = useRef(0);
 
   useEffect(() => {
     setReferenceState("loading");
@@ -95,15 +99,20 @@ function CreateTicketScreen({ requester, onBack }: CreateScreenProps) {
 
   function selectFiles(event: ChangeEvent<HTMLInputElement>) {
     const selected = Array.from(event.target.files ?? []);
-    const next = selected.slice(0, 5).map((file) => {
-      const extension = file.name.toLowerCase().split(".").pop();
-      const validType = ["jpg", "jpeg", "png", "webp", "pdf"].includes(extension ?? "");
-      if (!validType) return { file, error: "Unsupported file type." };
-      if (file.size > 5_242_880) return { file, error: "File exceeds 5 MiB." };
-      return { file };
+    setFiles((current) => {
+      let validCount = current.filter((item) => item.status !== "invalid").length;
+      const additions = selected.map((file) => {
+        const extension = file.name.toLowerCase().split(".").pop();
+        const validType = ["jpg", "jpeg", "png", "webp", "pdf"].includes(extension ?? "");
+        let error: string | undefined;
+        if (!validType) error = "Unsupported file type.";
+        else if (file.size > 5_242_880) error = "File exceeds 5 MiB.";
+        else if (validCount >= 5) error = "Maximum five valid files can be uploaded.";
+        else validCount += 1;
+        return { id: `${file.name}-${file.lastModified}-${fileId.current++}`, file, status: error ? "invalid" as const : "pending" as const, error };
+      });
+      return [...current, ...additions];
     });
-    if (selected.length > 5) next.push({ file: selected[5], error: "Maximum five files can be selected." });
-    setFiles(next);
     event.target.value = "";
   }
 
@@ -128,11 +137,9 @@ function CreateTicketScreen({ requester, onBack }: CreateScreenProps) {
     if (!validateForm()) return;
     setSubmitState("submitting");
     setSubmitError(null);
-    setAttachmentResults([]);
-    setFailedUploadFiles([]);
     try {
       const created = await createTicket(requester.id, {
-        clientRequestId: globalThis.crypto.randomUUID(),
+        clientRequestId,
         categoryId: Number(form.categoryId),
         relatedSystemId: Number(form.relatedSystemId),
         requestedPriority: form.requestedPriority as "LOW" | "MEDIUM" | "HIGH" | "URGENT",
@@ -140,13 +147,8 @@ function CreateTicketScreen({ requester, onBack }: CreateScreenProps) {
         description: form.description.trim(),
       });
       setTicket(created.ticket);
-      const results = await Promise.all(files.filter((item) => !item.error).map(async ({ file }) => {
-        try { await uploadTicketAttachment(requester.id, created.ticket.id, file); return { name: file.name, ok: true }; }
-        catch (error) { return { name: file.name, ok: false, message: error instanceof Error ? error.message : "Upload failed." }; }
-      }));
-      setAttachmentResults([...files.filter((item) => item.error).map(({ file, error }) => ({ name: file.name, ok: false, message: error })), ...results]);
-      setFailedUploadFiles(files.filter((item) => !item.error).map(({ file }, index) => results[index]?.ok ? null : file).filter((file): file is File => file !== null));
       setSubmitState("success");
+      await Promise.all(files.filter((item) => item.status !== "invalid").map((item) => uploadAttachment(item, created.ticket.id)));
     } catch (error) {
       setSubmitState("error");
       const apiError = error as { message?: string; fieldErrors?: Record<string, string[]> };
@@ -155,22 +157,26 @@ function CreateTicketScreen({ requester, onBack }: CreateScreenProps) {
     }
   }
 
-  async function retryFailedAttachments() {
-    if (!ticket || failedUploadFiles.length === 0) return;
-    setRetryingAttachments(true);
-    const retryResults = await Promise.all(failedUploadFiles.map(async (file) => {
-      try { await uploadTicketAttachment(requester.id, ticket.id, file); return { name: file.name, ok: true }; }
-      catch (error) { return { name: file.name, ok: false, message: error instanceof Error ? error.message : "Upload failed." }; }
-    }));
-    setAttachmentResults((current) => current.map((result) => retryResults.find((retry) => retry.name === result.name) ?? result));
-    setFailedUploadFiles(failedUploadFiles.filter((file, index) => !retryResults[index].ok));
-    setRetryingAttachments(false);
+  async function uploadAttachment(selected: SelectedFile, ticketId: number) {
+    setFiles((current) => current.map((item) => item.id === selected.id ? { ...item, status: "uploading", message: undefined } : item));
+    try {
+      await uploadTicketAttachment(requester.id, ticketId, selected.file);
+      setFiles((current) => current.map((item) => item.id === selected.id ? { ...item, status: "uploaded", message: undefined } : item));
+    } catch (error) {
+      setFiles((current) => current.map((item) => item.id === selected.id ? { ...item, status: "failed", message: error instanceof Error ? error.message : "Upload failed." } : item));
+    }
+  }
+
+  async function retryAttachment(id: string) {
+    if (!ticket) return;
+    const selected = files.find((item) => item.id === id);
+    if (selected?.status === "failed") await uploadAttachment(selected, ticket.id);
   }
 
   if (submitState === "success" && ticket) return (
     <main className="shell-content" id="create-ticket">
       <div className="alert alert-success" role="status"><h1>Ticket created</h1><p>Official Ticket Number: <strong>{ticket.ticketNumber}</strong></p></div>
-      {attachmentResults.length > 0 && <section className="context-card"><h2>Attachment results</h2><ul>{attachmentResults.map((result) => <li key={result.name}>{result.name}: {result.ok ? "Uploaded" : result.message}</li>)}</ul>{failedUploadFiles.length > 0 && <button className="button button-secondary" type="button" onClick={retryFailedAttachments} disabled={retryingAttachments}>{retryingAttachments ? "Retrying uploads…" : "Retry failed uploads"}</button>}</section>}
+      {files.length > 0 && <section className="context-card"><h2>Attachment results</h2><ul>{files.map((selected) => <li key={selected.id}>{selected.file.name}: {selected.status === "uploaded" ? "Uploaded" : selected.status === "invalid" ? selected.error : selected.status === "uploading" ? "Uploading…" : selected.message}{selected.status === "failed" && <button className="button button-secondary file-retry" type="button" onClick={() => retryAttachment(selected.id)}>Retry</button>}</li>)}</ul></section>}
       <button className="button button-secondary" onClick={onBack}>Back to workspace</button>
     </main>
   );
@@ -194,8 +200,8 @@ function CreateTicketScreen({ requester, onBack }: CreateScreenProps) {
         <label htmlFor="summary">Summary <span aria-hidden="true">*</span><input id="summary" value={form.summary} maxLength={120} onChange={(event) => updateField("summary", event.target.value)} disabled={submitState === "submitting"} aria-invalid={Boolean(fieldErrors.summary)} aria-describedby={fieldErrors.summary ? "summary-error summary-count" : "summary-count"} required />{fieldErrors.summary && <small id="summary-error" className="field-error">{fieldErrors.summary}</small>}<small id="summary-count">{form.summary.length}/120</small></label>
         <label htmlFor="description">Description <span aria-hidden="true">*</span><textarea id="description" value={form.description} maxLength={5000} onChange={(event) => updateField("description", event.target.value)} disabled={submitState === "submitting"} aria-invalid={Boolean(fieldErrors.description)} aria-describedby={fieldErrors.description ? "description-error description-count" : "description-count"} required />{fieldErrors.description && <small id="description-error" className="field-error">{fieldErrors.description}</small>}<small id="description-count">{form.description.length}/5000</small></label>
         <label htmlFor="attachments">Attachments<input id="attachments" type="file" multiple accept=".jpg,.jpeg,.png,.webp,.pdf" onChange={selectFiles} disabled={submitState === "submitting"} /><small>JPG, JPEG, PNG, WEBP, or PDF; maximum 5 MiB each; maximum 5 files</small></label>
-        {files.length > 0 && <ul className="file-list">{files.map(({ file, error }, index) => <li key={`${file.name}-${file.lastModified}`}>{file.name} ({Math.ceil(file.size / 1024)} KiB){error && <span className="field-error"> — {error}</span>}<button type="button" className="file-remove" onClick={() => removeSelectedFile(index)} disabled={submitState === "submitting"}>Remove</button></li>)}</ul>}
-        <div className="form-actions"><button type="button" className="button button-secondary" onClick={onBack} disabled={submitState === "submitting"}>Cancel</button><button type="submit" className="button button-primary submit-button" disabled={submitState === "submitting"}>{submitState === "submitting" ? "Submitting…" : "Submit Ticket"}</button></div>
+        {files.length > 0 && <ul className="file-list">{files.map(({ id, file, error }, index) => <li key={id}>{file.name} ({Math.ceil(file.size / 1024)} KiB){error && <span className="field-error"> — {error}</span>}<button type="button" className="file-remove" onClick={() => removeSelectedFile(index)} disabled={submitState === "submitting"}>Remove</button></li>)}</ul>}
+        <div className="form-actions"><button type="button" className="button button-secondary" onClick={onBack} disabled={submitState === "submitting"}>Cancel</button><button type="submit" className="button button-primary submit-button" disabled={referenceState !== "ready" || submitState === "submitting"}>{submitState === "submitting" ? "Submitting…" : "Submit Ticket"}</button></div>
       </form>
     </main>
   );

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { DevelopmentRequester, getDevelopmentRequesters } from "./api.js";
+import { useEffect, useState, type ChangeEvent, type FormEvent } from "react";
+import { createTicket, CreatedTicket, DevelopmentRequester, getCategories, getDevelopmentRequesters, getRelatedSystems, ReferenceItem, uploadTicketAttachment } from "./api.js";
 import "./App.css";
 
 const REQUESTER_STORAGE_KEY = "toktickit.requesterId";
@@ -61,7 +61,148 @@ function RequesterSelector({
   );
 }
 
+type CreateScreenProps = { requester: DevelopmentRequester; onBack: () => void };
+type SelectedFile = { file: File; error?: string };
+
+function CreateTicketScreen({ requester, onBack }: CreateScreenProps) {
+  const [categories, setCategories] = useState<ReferenceItem[]>([]);
+  const [relatedSystems, setRelatedSystems] = useState<ReferenceItem[]>([]);
+  const [referenceState, setReferenceState] = useState<"loading" | "ready" | "error">("loading");
+  const [referenceError, setReferenceError] = useState<string | null>(null);
+  const [referenceRetryToken, setReferenceRetryToken] = useState(0);
+  const [form, setForm] = useState({ categoryId: "", relatedSystemId: "", requestedPriority: "MEDIUM", summary: "", description: "" });
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [files, setFiles] = useState<SelectedFile[]>([]);
+  const [submitState, setSubmitState] = useState<"idle" | "submitting" | "success" | "error">("idle");
+  const [ticket, setTicket] = useState<CreatedTicket | null>(null);
+  const [attachmentResults, setAttachmentResults] = useState<{ name: string; ok: boolean; message?: string }[]>([]);
+  const [failedUploadFiles, setFailedUploadFiles] = useState<File[]>([]);
+  const [retryingAttachments, setRetryingAttachments] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setReferenceState("loading");
+    setReferenceError(null);
+    Promise.all([getCategories(), getRelatedSystems()])
+      .then(([loadedCategories, loadedSystems]) => { setCategories(loadedCategories); setRelatedSystems(loadedSystems); setReferenceState("ready"); })
+      .catch(() => { setCategories([]); setRelatedSystems([]); setReferenceState("error"); setReferenceError("Unable to load Ticket reference data. Please try again."); });
+  }, [referenceRetryToken]);
+
+  function updateField(field: keyof typeof form, value: string) {
+    setForm((current) => ({ ...current, [field]: value }));
+    setFieldErrors((current) => ({ ...current, [field]: "" }));
+  }
+
+  function selectFiles(event: ChangeEvent<HTMLInputElement>) {
+    const selected = Array.from(event.target.files ?? []);
+    const next = selected.slice(0, 5).map((file) => {
+      const extension = file.name.toLowerCase().split(".").pop();
+      const validType = ["jpg", "jpeg", "png", "webp", "pdf"].includes(extension ?? "");
+      if (!validType) return { file, error: "Unsupported file type." };
+      if (file.size > 5_242_880) return { file, error: "File exceeds 5 MiB." };
+      return { file };
+    });
+    if (selected.length > 5) next.push({ file: selected[5], error: "Maximum five files can be selected." });
+    setFiles(next);
+    event.target.value = "";
+  }
+
+  function removeSelectedFile(index: number) {
+    setFiles((current) => current.filter((_, fileIndex) => fileIndex !== index));
+  }
+
+  function validateForm() {
+    const errors: Record<string, string> = {};
+    if (!form.categoryId) errors.categoryId = "Category is required.";
+    if (!form.relatedSystemId) errors.relatedSystemId = "Related System is required.";
+    if (form.summary.trim().length < 5 || form.summary.trim().length > 120) errors.summary = "Summary must contain 5 to 120 characters.";
+    if (form.description.trim().length < 10 || form.description.trim().length > 5000) errors.description = "Description must contain 10 to 5,000 characters.";
+    setFieldErrors(errors);
+    const firstInvalid = ["categoryId", "relatedSystemId", "summary", "description"].find((field) => errors[field]);
+    if (firstInvalid) window.setTimeout(() => document.getElementById(firstInvalid)?.focus(), 0);
+    return Object.keys(errors).length === 0;
+  }
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    if (!validateForm()) return;
+    setSubmitState("submitting");
+    setSubmitError(null);
+    setAttachmentResults([]);
+    setFailedUploadFiles([]);
+    try {
+      const created = await createTicket(requester.id, {
+        clientRequestId: globalThis.crypto.randomUUID(),
+        categoryId: Number(form.categoryId),
+        relatedSystemId: Number(form.relatedSystemId),
+        requestedPriority: form.requestedPriority as "LOW" | "MEDIUM" | "HIGH" | "URGENT",
+        summary: form.summary.trim(),
+        description: form.description.trim(),
+      });
+      setTicket(created.ticket);
+      const results = await Promise.all(files.filter((item) => !item.error).map(async ({ file }) => {
+        try { await uploadTicketAttachment(requester.id, created.ticket.id, file); return { name: file.name, ok: true }; }
+        catch (error) { return { name: file.name, ok: false, message: error instanceof Error ? error.message : "Upload failed." }; }
+      }));
+      setAttachmentResults([...files.filter((item) => item.error).map(({ file, error }) => ({ name: file.name, ok: false, message: error })), ...results]);
+      setFailedUploadFiles(files.filter((item) => !item.error).map(({ file }, index) => results[index]?.ok ? null : file).filter((file): file is File => file !== null));
+      setSubmitState("success");
+    } catch (error) {
+      setSubmitState("error");
+      const apiError = error as { message?: string; fieldErrors?: Record<string, string[]> };
+      setSubmitError(apiError.message ?? "Unable to create Ticket. Please try again.");
+      if (apiError.fieldErrors) setFieldErrors(Object.fromEntries(Object.entries(apiError.fieldErrors).map(([key, messages]) => [key, messages[0]])));
+    }
+  }
+
+  async function retryFailedAttachments() {
+    if (!ticket || failedUploadFiles.length === 0) return;
+    setRetryingAttachments(true);
+    const retryResults = await Promise.all(failedUploadFiles.map(async (file) => {
+      try { await uploadTicketAttachment(requester.id, ticket.id, file); return { name: file.name, ok: true }; }
+      catch (error) { return { name: file.name, ok: false, message: error instanceof Error ? error.message : "Upload failed." }; }
+    }));
+    setAttachmentResults((current) => current.map((result) => retryResults.find((retry) => retry.name === result.name) ?? result));
+    setFailedUploadFiles(failedUploadFiles.filter((file, index) => !retryResults[index].ok));
+    setRetryingAttachments(false);
+  }
+
+  if (submitState === "success" && ticket) return (
+    <main className="shell-content" id="create-ticket">
+      <div className="alert alert-success" role="status"><h1>Ticket created</h1><p>Official Ticket Number: <strong>{ticket.ticketNumber}</strong></p></div>
+      {attachmentResults.length > 0 && <section className="context-card"><h2>Attachment results</h2><ul>{attachmentResults.map((result) => <li key={result.name}>{result.name}: {result.ok ? "Uploaded" : result.message}</li>)}</ul>{failedUploadFiles.length > 0 && <button className="button button-secondary" type="button" onClick={retryFailedAttachments} disabled={retryingAttachments}>{retryingAttachments ? "Retrying uploads…" : "Retry failed uploads"}</button>}</section>}
+      <button className="button button-secondary" onClick={onBack}>Back to workspace</button>
+    </main>
+  );
+
+  return (
+    <main className="shell-content" id="create-ticket">
+      <button className="back-button" onClick={onBack}>← Back to workspace</button>
+      <p className="eyebrow">Requester workspace</p>
+      <h1>Create Ticket</h1>
+      <p className="intro">Describe your IT request. Fields marked <span aria-hidden="true">*</span> are required.</p>
+      {referenceState === "loading" && <div className="alert" role="status">Loading Ticket reference data…</div>}
+      {referenceError && <div className="alert alert-error" role="alert">{referenceError}<button className="button button-secondary retry-button" type="button" onClick={() => setReferenceRetryToken((token) => token + 1)}>Retry</button></div>}
+      {submitError && <div className="alert alert-error" role="alert">{submitError}<button className="button button-secondary retry-button" type="button" onClick={() => { setSubmitError(null); setSubmitState("idle"); }}>Retry</button></div>}
+      <form className="ticket-form" onSubmit={submit} noValidate aria-busy={referenceState === "loading" || submitState === "submitting"}>
+        <div className="readonly-grid"><label>Ticket Number<input value="Generated after submission" readOnly /></label><label>Ticket Date<input value="Recorded after submission" readOnly /></label><label>Requester<input value={requester.name} readOnly /></label></div>
+        <div className="form-grid">
+          <label htmlFor="category-id">Category <span aria-hidden="true">*</span><select id="category-id" value={form.categoryId} onChange={(event) => updateField("categoryId", event.target.value)} disabled={referenceState !== "ready" || submitState === "submitting"} aria-invalid={Boolean(fieldErrors.categoryId)} aria-describedby={fieldErrors.categoryId ? "category-error" : undefined} required><option value="">Select Category</option>{categories.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}</select>{fieldErrors.categoryId && <small id="category-error" className="field-error">{fieldErrors.categoryId}</small>}</label>
+          <label htmlFor="related-system-id">Related System <span aria-hidden="true">*</span><select id="related-system-id" value={form.relatedSystemId} onChange={(event) => updateField("relatedSystemId", event.target.value)} disabled={referenceState !== "ready" || submitState === "submitting"} aria-invalid={Boolean(fieldErrors.relatedSystemId)} aria-describedby={fieldErrors.relatedSystemId ? "related-system-error" : undefined} required><option value="">Select Related System</option>{relatedSystems.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}</select>{fieldErrors.relatedSystemId && <small id="related-system-error" className="field-error">{fieldErrors.relatedSystemId}</small>}</label>
+          <label htmlFor="requested-priority">Requested Priority <select id="requested-priority" value={form.requestedPriority} onChange={(event) => updateField("requestedPriority", event.target.value)} disabled={submitState === "submitting"}><option>LOW</option><option>MEDIUM</option><option>HIGH</option><option>URGENT</option></select></label>
+        </div>
+        <label htmlFor="summary">Summary <span aria-hidden="true">*</span><input id="summary" value={form.summary} maxLength={120} onChange={(event) => updateField("summary", event.target.value)} disabled={submitState === "submitting"} aria-invalid={Boolean(fieldErrors.summary)} aria-describedby={fieldErrors.summary ? "summary-error summary-count" : "summary-count"} required />{fieldErrors.summary && <small id="summary-error" className="field-error">{fieldErrors.summary}</small>}<small id="summary-count">{form.summary.length}/120</small></label>
+        <label htmlFor="description">Description <span aria-hidden="true">*</span><textarea id="description" value={form.description} maxLength={5000} onChange={(event) => updateField("description", event.target.value)} disabled={submitState === "submitting"} aria-invalid={Boolean(fieldErrors.description)} aria-describedby={fieldErrors.description ? "description-error description-count" : "description-count"} required />{fieldErrors.description && <small id="description-error" className="field-error">{fieldErrors.description}</small>}<small id="description-count">{form.description.length}/5000</small></label>
+        <label htmlFor="attachments">Attachments<input id="attachments" type="file" multiple accept=".jpg,.jpeg,.png,.webp,.pdf" onChange={selectFiles} disabled={submitState === "submitting"} /><small>JPG, JPEG, PNG, WEBP, or PDF; maximum 5 MiB each; maximum 5 files</small></label>
+        {files.length > 0 && <ul className="file-list">{files.map(({ file, error }, index) => <li key={`${file.name}-${file.lastModified}`}>{file.name} ({Math.ceil(file.size / 1024)} KiB){error && <span className="field-error"> — {error}</span>}<button type="button" className="file-remove" onClick={() => removeSelectedFile(index)} disabled={submitState === "submitting"}>Remove</button></li>)}</ul>}
+        <div className="form-actions"><button type="button" className="button button-secondary" onClick={onBack} disabled={submitState === "submitting"}>Cancel</button><button type="submit" className="button button-primary submit-button" disabled={submitState === "submitting"}>{submitState === "submitting" ? "Submitting…" : "Submit Ticket"}</button></div>
+      </form>
+    </main>
+  );
+}
+
 function ApplicationShell({ requester, onChangeRequester }: { requester: DevelopmentRequester; onChangeRequester: () => void }) {
+  const [screen, setScreen] = useState<"home" | "create">("home");
   return (
     <div className="app-shell">
       <header className="app-header">
@@ -70,7 +211,7 @@ function ApplicationShell({ requester, onChangeRequester }: { requester: Develop
           <nav aria-label="Primary navigation">
             <a href="#home" aria-current="page">Workspace</a>
             <button className="nav-unavailable" type="button" disabled title="Available in a later Lab 2 feature">My Tickets <span>(coming soon)</span></button>
-            <button className="nav-unavailable" type="button" disabled title="Available in a later Lab 2 feature">Create Ticket <span>(coming soon)</span></button>
+            <button className={screen === "create" ? "nav-create active" : "nav-create"} type="button" onClick={() => setScreen("create")} aria-current={screen === "create" ? "page" : undefined}>Create Ticket</button>
           </nav>
           <div className="requester-context">
             <span>Requester: {requester.name}</span>
@@ -78,12 +219,12 @@ function ApplicationShell({ requester, onChangeRequester }: { requester: Develop
           </div>
         </div>
       </header>
-      <main className="shell-content" id="home">
+      {screen === "create" ? <CreateTicketScreen requester={requester} onBack={() => setScreen("home")} /> : <main className="shell-content" id="home">
         <p className="eyebrow">Requester workspace</p>
         <h1>Welcome to TokTickIT</h1>
         <p>Your requester context is ready. Choose an action from the navigation when the corresponding Lab 2 screen is available.</p>
         <div className="context-card" role="status">Testing as <strong>{requester.name}</strong></div>
-      </main>
+      </main>}
     </div>
   );
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -10,6 +10,39 @@ export interface DevelopmentRequester {
   name: string;
 }
 
+export interface ReferenceItem {
+  id: number;
+  name: string;
+}
+
+export interface CreateTicketInput {
+  clientRequestId: string;
+  categoryId: number;
+  relatedSystemId: number;
+  summary: string;
+  requestedPriority: "LOW" | "MEDIUM" | "HIGH" | "URGENT";
+  description: string;
+}
+
+export interface CreatedTicket {
+  id: number;
+  ticketNumber: string;
+  ticketDate: string;
+  requester: DevelopmentRequester & { email: string };
+  category: ReferenceItem;
+  relatedSystem: ReferenceItem;
+  summary: string;
+  requestedPriority: CreateTicketInput["requestedPriority"];
+  description: string;
+  currentStatus: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ApiValidationError extends Error {
+  fieldErrors?: Record<string, string[]>;
+}
+
 export interface SystemStatus {
   online: boolean;
   categories: Category[];
@@ -57,4 +90,56 @@ export async function getDevelopmentRequesters(): Promise<DevelopmentRequester[]
     throw new Error("TokTickIT API returned an invalid Requester response");
   }
   return requesters;
+}
+
+async function throwApiError(response: Response, fallback: string): Promise<never> {
+  const body = await response.json().catch(() => null) as { error?: { message?: string; fieldErrors?: Record<string, string[]> } } | null;
+  const error = new Error(body?.error?.message ?? fallback) as ApiValidationError;
+  error.fieldErrors = body?.error?.fieldErrors;
+  throw error;
+}
+
+export async function getCategories(): Promise<ReferenceItem[]> {
+  const response = await fetch(`${API_URL}/api/categories`);
+  if (!response.ok) return throwApiError(response, "Unable to load Categories");
+  return parseReferenceItems(await response.json());
+}
+
+export async function getRelatedSystems(): Promise<ReferenceItem[]> {
+  const response = await fetch(`${API_URL}/api/related-systems`);
+  if (!response.ok) return throwApiError(response, "Unable to load Related Systems");
+  return parseReferenceItems(await response.json());
+}
+
+function parseReferenceItems(value: unknown): ReferenceItem[] {
+  if (!Array.isArray(value) || !value.every((item) => {
+    if (!item || typeof item !== "object") return false;
+    const candidate = item as Partial<ReferenceItem>;
+    return typeof candidate.id === "number" && Number.isSafeInteger(candidate.id) && candidate.id > 0 && typeof candidate.name === "string" && candidate.name.trim().length > 0;
+  })) {
+    throw new Error("TokTickIT API returned invalid reference data");
+  }
+  return value as ReferenceItem[];
+}
+
+export async function createTicket(requesterId: number, input: CreateTicketInput): Promise<{ ticket: CreatedTicket; replayed: boolean }> {
+  const response = await fetch(`${API_URL}/api/tickets`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "X-Requester-Id": String(requesterId) },
+    body: JSON.stringify(input),
+  });
+  if (!response.ok) return throwApiError(response, "Unable to create Ticket");
+  return await response.json() as { ticket: CreatedTicket; replayed: boolean };
+}
+
+export async function uploadTicketAttachment(requesterId: number, ticketId: number, file: File): Promise<unknown> {
+  const form = new FormData();
+  form.append("file", file);
+  const response = await fetch(`${API_URL}/api/tickets/${ticketId}/attachments`, {
+    method: "POST",
+    headers: { "X-Requester-Id": String(requesterId) },
+    body: form,
+  });
+  if (!response.ok) return throwApiError(response, "Unable to upload Attachment");
+  return response.json();
 }

--- a/client/tests/lab-02/CreateTicket.test.tsx
+++ b/client/tests/lab-02/CreateTicket.test.tsx
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import App from "../../src/App.js";
+import * as api from "../../src/api.js";
+
+const requester = { id: 1, name: "Alice Requester" };
+const ticket = {
+  id: 42,
+  ticketNumber: "TKT-2026-000042",
+  ticketDate: "2026-08-31T10:00:00.000Z",
+  requester: { ...requester, email: "alice@example.test" },
+  category: { id: 1, name: "Hardware" },
+  relatedSystem: { id: 1, name: "Corporate Laptop" },
+  summary: "Laptop battery issue",
+  requestedPriority: "MEDIUM" as const,
+  description: "Battery drains very quickly during normal use.",
+  currentStatus: "NEW",
+  createdAt: "2026-08-31T10:00:00.000Z",
+  updatedAt: "2026-08-31T10:00:00.000Z",
+};
+
+async function renderCreateTicket() {
+  sessionStorage.setItem("toktickit.requesterId", "1");
+  vi.spyOn(api, "getDevelopmentRequesters").mockResolvedValue([requester]);
+  vi.spyOn(api, "getCategories").mockResolvedValue([{ id: 1, name: "Hardware" }]);
+  vi.spyOn(api, "getRelatedSystems").mockResolvedValue([{ id: 1, name: "Corporate Laptop" }]);
+  render(<App />);
+  await screen.findByText("Welcome to TokTickIT");
+  fireEvent.click(screen.getByRole("button", { name: "Create Ticket" }));
+  await screen.findByRole("heading", { name: "Create Ticket" });
+}
+
+function fillValidForm() {
+  fireEvent.change(screen.getByLabelText(/Category/), { target: { value: "1" } });
+  fireEvent.change(screen.getByLabelText(/Related System/), { target: { value: "1" } });
+  fireEvent.change(screen.getByLabelText(/Summary/), { target: { value: "Laptop battery issue" } });
+  fireEvent.change(screen.getByLabelText(/Description/), { target: { value: "Battery drains very quickly during normal use." } });
+}
+
+afterEach(() => {
+  sessionStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("Create Ticket screen", () => {
+  it("loads reference data and shows read-only Ticket fields", async () => {
+    await renderCreateTicket();
+    expect(screen.getByDisplayValue("Generated after submission")).toHaveAttribute("readonly");
+    expect(screen.getByDisplayValue("Recorded after submission")).toHaveAttribute("readonly");
+    expect(screen.getByDisplayValue("Alice Requester")).toHaveAttribute("readonly");
+    expect(screen.getByRole("option", { name: "Hardware" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Corporate Laptop" })).toBeInTheDocument();
+  });
+
+  it("shows field-level validation without calling the API", async () => {
+    const create = vi.spyOn(api, "createTicket");
+    await renderCreateTicket();
+    fireEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+    expect(await screen.findByText("Category is required.")).toBeInTheDocument();
+    expect(screen.getByText("Summary must contain 5 to 120 characters.")).toBeInTheDocument();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("creates a Ticket and shows the authoritative Ticket Number", async () => {
+    vi.spyOn(api, "createTicket").mockResolvedValue({ ticket, replayed: false });
+    vi.spyOn(api, "uploadTicketAttachment").mockResolvedValue({});
+    await renderCreateTicket();
+    fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+    expect(await screen.findByRole("heading", { name: "Ticket created" })).toBeInTheDocument();
+    expect(screen.getByText("TKT-2026-000042")).toBeInTheDocument();
+  });
+
+  it("disables repeated submission and shows a busy label", async () => {
+    let resolveCreate!: (value: { ticket: typeof ticket; replayed: boolean }) => void;
+    vi.spyOn(api, "createTicket").mockImplementation(() => new Promise((resolve) => { resolveCreate = resolve; }));
+    await renderCreateTicket();
+    fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+    expect(screen.getByRole("button", { name: "Submitting…" })).toBeDisabled();
+    resolveCreate({ ticket, replayed: false });
+    expect(await screen.findByText("TKT-2026-000042")).toBeInTheDocument();
+  });
+
+  it("preserves the form and shows a safe create failure", async () => {
+    vi.spyOn(api, "createTicket").mockRejectedValue(new Error("Unable to create Ticket. Please try again."));
+    await renderCreateTicket();
+    fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to create Ticket");
+    expect(screen.getByDisplayValue("Laptop battery issue")).toBeInTheDocument();
+  });
+
+  it("keeps invalid selected files visible and excludes them from upload", async () => {
+    vi.spyOn(api, "createTicket").mockResolvedValue({ ticket, replayed: false });
+    vi.spyOn(api, "uploadTicketAttachment").mockResolvedValue({});
+    await renderCreateTicket();
+    const input = screen.getByLabelText(/Attachments/) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [new File(["x"], "notes.txt", { type: "text/plain" })] } });
+    expect(await screen.findByRole("listitem")).toHaveTextContent("notes.txt");
+    expect(screen.getByRole("listitem")).toHaveTextContent("Unsupported file type.");
+    fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+    await waitFor(() => expect(screen.getByText("Ticket created")).toBeInTheDocument());
+    expect(api.uploadTicketAttachment).not.toHaveBeenCalled();
+  });
+
+  it("reports partial Attachment failure after Ticket success", async () => {
+    vi.spyOn(api, "createTicket").mockResolvedValue({ ticket, replayed: false });
+    vi.spyOn(api, "uploadTicketAttachment").mockRejectedValue(new Error("Attachment unavailable"));
+    await renderCreateTicket();
+    fillValidForm();
+    const input = screen.getByLabelText(/Attachments/) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [new File(["%PDF-1.7"], "evidence.pdf", { type: "application/pdf" })] } });
+    fireEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+    expect(await screen.findByText(/evidence\.pdf: Attachment unavailable/)).toBeInTheDocument();
+  });
+});

--- a/client/tests/lab-02/CreateTicket.test.tsx
+++ b/client/tests/lab-02/CreateTicket.test.tsx
@@ -48,6 +48,7 @@ describe("Create Ticket screen", () => {
     expect(screen.getByDisplayValue("Generated after submission")).toHaveAttribute("readonly");
     expect(screen.getByDisplayValue("Recorded after submission")).toHaveAttribute("readonly");
     expect(screen.getByDisplayValue("Alice Requester")).toHaveAttribute("readonly");
+    expect(screen.getByLabelText(/Requested Priority/)).toHaveValue("MEDIUM");
     expect(screen.getByRole("option", { name: "Hardware" })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "Corporate Laptop" })).toBeInTheDocument();
   });
@@ -91,6 +92,25 @@ describe("Create Ticket screen", () => {
     expect(screen.getByDisplayValue("Laptop battery issue")).toBeInTheDocument();
   });
 
+  it("retains form/files and reuses the same clientRequestId after create retry", async () => {
+    const create = vi.spyOn(api, "createTicket")
+      .mockRejectedValueOnce(new Error("Unable to create Ticket. Please try again."))
+      .mockResolvedValueOnce({ ticket, replayed: true });
+    vi.spyOn(api, "uploadTicketAttachment").mockResolvedValue({});
+    await renderCreateTicket();
+    fillValidForm();
+    const attachment = new File(["content"], "evidence.pdf", { type: "application/pdf" });
+    fireEvent.change(screen.getByLabelText(/Attachments/), { target: { files: [attachment] } });
+    fireEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to create Ticket");
+    expect(screen.getByRole("listitem")).toHaveTextContent("evidence.pdf");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    fireEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+    await screen.findByRole("heading", { name: "Ticket created" });
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(create.mock.calls[0][1].clientRequestId).toBe(create.mock.calls[1][1].clientRequestId);
+  });
+
   it("keeps invalid selected files visible and excludes them from upload", async () => {
     vi.spyOn(api, "createTicket").mockResolvedValue({ ticket, replayed: false });
     vi.spyOn(api, "uploadTicketAttachment").mockResolvedValue({});
@@ -107,12 +127,53 @@ describe("Create Ticket screen", () => {
 
   it("reports partial Attachment failure after Ticket success", async () => {
     vi.spyOn(api, "createTicket").mockResolvedValue({ ticket, replayed: false });
-    vi.spyOn(api, "uploadTicketAttachment").mockRejectedValue(new Error("Attachment unavailable"));
+    const upload = vi.spyOn(api, "uploadTicketAttachment")
+      .mockRejectedValueOnce(new Error("Attachment unavailable"))
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
     await renderCreateTicket();
     fillValidForm();
     const input = screen.getByLabelText(/Attachments/) as HTMLInputElement;
-    fireEvent.change(input, { target: { files: [new File(["%PDF-1.7"], "evidence.pdf", { type: "application/pdf" })] } });
+    const first = new File(["content"], "first.pdf", { type: "application/pdf" });
+    const second = new File(["content"], "second.pdf", { type: "application/pdf" });
+    fireEvent.change(input, { target: { files: [first, second] } });
     fireEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
-    expect(await screen.findByText(/evidence\.pdf: Attachment unavailable/)).toBeInTheDocument();
+    expect(await screen.findByText("first.pdf: Attachment unavailable")).toBeInTheDocument();
+    expect(screen.getByText("second.pdf: Uploaded")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(screen.getByText("first.pdf: Uploaded")).toBeInTheDocument());
+    expect(upload).toHaveBeenCalledTimes(3);
+    expect(upload.mock.calls[2][2]).toBe(first);
+  });
+
+  it("appends picker selections and keeps every over-quota file visible", async () => {
+    await renderCreateTicket();
+    const input = screen.getByLabelText(/Attachments/);
+    fireEvent.change(input, { target: { files: [new File(["a"], "one.pdf"), new File(["b"], "two.pdf")] } });
+    fireEvent.change(input, { target: { files: [new File(["c"], "three.pdf"), new File(["d"], "four.pdf"), new File(["e"], "five.pdf"), new File(["f"], "six.pdf")] } });
+    expect(screen.getAllByRole("listitem")).toHaveLength(6);
+    expect(screen.getAllByRole("listitem")[5]).toHaveTextContent("Maximum five valid files");
+  });
+
+  it("does not let invalid files consume the five-file quota", async () => {
+    vi.spyOn(api, "createTicket").mockResolvedValue({ ticket, replayed: false });
+    const upload = vi.spyOn(api, "uploadTicketAttachment").mockResolvedValue({});
+    await renderCreateTicket();
+    const input = screen.getByLabelText(/Attachments/);
+    fireEvent.change(input, { target: { files: [new File(["x"], "notes.txt", { type: "text/plain" }), new File(["1"], "one.pdf"), new File(["2"], "two.pdf"), new File(["3"], "three.pdf"), new File(["4"], "four.pdf"), new File(["5"], "five.pdf")] } });
+    expect(screen.getAllByRole("listitem")).toHaveLength(6);
+    fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+    await screen.findByRole("heading", { name: "Ticket created" });
+    expect(upload).toHaveBeenCalledTimes(5);
+  });
+
+  it("removes a selected file before submission", async () => {
+    await renderCreateTicket();
+    const input = screen.getByLabelText(/Attachments/);
+    fireEvent.change(input, { target: { files: [new File(["x"], "remove-me.pdf")] } });
+    expect(screen.getByRole("listitem")).toHaveTextContent("remove-me.pdf");
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    expect(screen.queryByText("remove-me.pdf")).not.toBeInTheDocument();
   });
 });

--- a/client/tests/lab-02/CreateTicket.test.tsx
+++ b/client/tests/lab-02/CreateTicket.test.tsx
@@ -72,6 +72,22 @@ describe("Create Ticket screen", () => {
     expect(screen.getByText("TKT-2026-000042")).toBeInTheDocument();
   });
 
+  it("generates a new clientRequestId when starting a fresh Ticket", async () => {
+    const create = vi.spyOn(api, "createTicket").mockResolvedValue({ ticket, replayed: false });
+    await renderCreateTicket();
+    fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+    await screen.findByRole("heading", { name: "Ticket created" });
+    fireEvent.click(screen.getByRole("button", { name: "Create another Ticket" }));
+    await screen.findByRole("heading", { name: "Create Ticket" });
+    await waitFor(() => expect(screen.getByRole("combobox", { name: /Category/ })).toBeEnabled());
+    fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+    await screen.findByRole("heading", { name: "Ticket created" });
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(create.mock.calls[0][1].clientRequestId).not.toBe(create.mock.calls[1][1].clientRequestId);
+  });
+
   it("disables repeated submission and shows a busy label", async () => {
     let resolveCreate!: (value: { ticket: typeof ticket; replayed: boolean }) => void;
     vi.spyOn(api, "createTicket").mockImplementation(() => new Promise((resolve) => { resolveCreate = resolve; }));
@@ -149,8 +165,8 @@ describe("Create Ticket screen", () => {
   it("appends picker selections and keeps every over-quota file visible", async () => {
     await renderCreateTicket();
     const input = screen.getByLabelText(/Attachments/);
-    fireEvent.change(input, { target: { files: [new File(["a"], "one.pdf"), new File(["b"], "two.pdf")] } });
-    fireEvent.change(input, { target: { files: [new File(["c"], "three.pdf"), new File(["d"], "four.pdf"), new File(["e"], "five.pdf"), new File(["f"], "six.pdf")] } });
+    fireEvent.change(input, { target: { files: [new File(["a"], "one.pdf", { type: "application/pdf" }), new File(["b"], "two.pdf", { type: "application/pdf" })] } });
+    fireEvent.change(input, { target: { files: [new File(["c"], "three.pdf", { type: "application/pdf" }), new File(["d"], "four.pdf", { type: "application/pdf" }), new File(["e"], "five.pdf", { type: "application/pdf" }), new File(["f"], "six.pdf", { type: "application/pdf" })] } });
     expect(screen.getAllByRole("listitem")).toHaveLength(6);
     expect(screen.getAllByRole("listitem")[5]).toHaveTextContent("Maximum five valid files");
   });
@@ -160,12 +176,19 @@ describe("Create Ticket screen", () => {
     const upload = vi.spyOn(api, "uploadTicketAttachment").mockResolvedValue({});
     await renderCreateTicket();
     const input = screen.getByLabelText(/Attachments/);
-    fireEvent.change(input, { target: { files: [new File(["x"], "notes.txt", { type: "text/plain" }), new File(["1"], "one.pdf"), new File(["2"], "two.pdf"), new File(["3"], "three.pdf"), new File(["4"], "four.pdf"), new File(["5"], "five.pdf")] } });
+    fireEvent.change(input, { target: { files: [new File(["x"], "notes.txt", { type: "text/plain" }), new File(["1"], "one.pdf", { type: "application/pdf" }), new File(["2"], "two.pdf", { type: "application/pdf" }), new File(["3"], "three.pdf", { type: "application/pdf" }), new File(["4"], "four.pdf", { type: "application/pdf" }), new File(["5"], "five.pdf", { type: "application/pdf" })] } });
     expect(screen.getAllByRole("listitem")).toHaveLength(6);
     fillValidForm();
     fireEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
     await screen.findByRole("heading", { name: "Ticket created" });
     expect(upload).toHaveBeenCalledTimes(5);
+  });
+
+  it("rejects an Attachment when extension and MIME type do not match", async () => {
+    await renderCreateTicket();
+    const input = screen.getByLabelText(/Attachments/);
+    fireEvent.change(input, { target: { files: [new File(["x"], "wrong.pdf", { type: "image/png" })] } });
+    expect(screen.getByRole("listitem")).toHaveTextContent("MIME type must be application/pdf.");
   });
 
   it("removes a selected file before submission", async () => {

--- a/client/tests/lab-02/DevelopmentRequesterSelect.test.tsx
+++ b/client/tests/lab-02/DevelopmentRequesterSelect.test.tsx
@@ -43,7 +43,7 @@ describe("Development Requester selection and context", () => {
     await waitFor(() => expect(screen.getByText("Requester: Bob Requester")).toBeInTheDocument());
     expect(sessionStorage.getItem("toktickit.requesterId")).toBe("2");
     expect(screen.getByRole("button", { name: /My Tickets \(coming soon\)/i })).toBeDisabled();
-    expect(screen.getByRole("button", { name: /Create Ticket \(coming soon\)/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Create Ticket" })).toBeEnabled();
   });
 
   it("restores a valid Requester and allows changing context", async () => {

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -76,13 +76,13 @@ Database tests use a dedicated test database/schema. Attachment tests use a task
 | UI-01 | FR-01, AC-01 | Route guard without Requester | Selector shown; protected screen absent | `client/tests/lab-02/DevelopmentRequesterSelect.test.tsx` | PASS |
 | UI-02 | FR-02-FR-03, AC-02-AC-03 | Selector ready/loading/empty/failure | Correct accessible states/Retry | `client/tests/lab-02/DevelopmentRequesterSelect.test.tsx` | PASS |
 | UI-03 | FR-04-FR-06, AC-04-AC-05 | Restore/current identity/Change Requester | Header updates; A state cleared; B is revalidated and rendered | `client/tests/lab-02/DevelopmentRequesterSelect.test.tsx` | PASS |
-| UI-04 | FR-07-FR-09, AC-06 | Create initial/reference/read-only fields | API data, current Requester, pending values | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
-| UI-05 | FR-10, BR-14-BR-17, AC-07 | Field validation/focus | Near-field errors; no API call; focus first invalid | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
-| UI-06 | FR-11, AC-08 | Successful creation | Backend Ticket Number/saved values/next actions | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
-| UI-07 | FR-12, AC-10 | Busy/disabled Submit | One request; visible busy text | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
-| UI-08 | FR-13, AC-11 | Create API failure | Safe alert; values/files retained; Retry | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
-| UI-09 | FR-14, AC-12 | Partial Attachment failure | Ticket success retained; failed file/retry shown | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
-| UI-10 | BR-29-BR-32, AC-23 | Invalid/sixth selected file | Per-file reason; invalid not submitted | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
+| UI-04 | FR-07-FR-09, AC-06 | Create initial/reference/read-only fields | API data, current Requester, pending values | `client/tests/lab-02/CreateTicket.test.tsx` | PASS |
+| UI-05 | FR-10, BR-14-BR-17, AC-07 | Field validation/focus | Near-field errors; no API call; focus first invalid | `client/tests/lab-02/CreateTicket.test.tsx` | PASS |
+| UI-06 | FR-11, AC-08 | Successful creation | Backend Ticket Number/saved values/next actions | `client/tests/lab-02/CreateTicket.test.tsx` | PASS |
+| UI-07 | FR-12, AC-10 | Busy/disabled Submit | One request; visible busy text | `client/tests/lab-02/CreateTicket.test.tsx` | PASS |
+| UI-08 | FR-13, AC-11 | Create API failure | Safe alert; values/files retained; Retry | `client/tests/lab-02/CreateTicket.test.tsx` | PASS |
+| UI-09 | FR-14, AC-12 | Partial Attachment failure | Ticket success retained; failed file/retry shown | `client/tests/lab-02/CreateTicket.test.tsx` | PASS |
+| UI-10 | BR-29-BR-32, AC-23 | Invalid/sixth selected file | Per-file reason; invalid not submitted | `client/tests/lab-02/CreateTicket.test.tsx` | PASS |
 | UI-11 | FR-15, AC-13 | My Tickets owner switch | A disappears; loading then B appears | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
 | UI-12 | FR-16-FR-17, AC-14-AC-15 | Search/filters/Clear | Correct query/page reset/preserved controls | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
 | UI-13 | FR-18-FR-19, AC-16-AC-17 | Sort/page/page size | Correct query and control states | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
@@ -192,7 +192,7 @@ Focused commands belong in Issue/PR evidence; final evidence must come from comp
 
 ### Lab 2
 
-**Status:** Feature 12 Requester Selection and Application Shell implemented on branch `feature/12-lab2-requester-selection`; backend/API and later Ticket screens remain separate Features.
+**Status:** Feature 13 Create Ticket UI is implemented on branch `feature/13-lab2-create-ticket-ui`; My Tickets and Ticket Detail remain separate Features.
 
 ### Feature 10 Evidence
 
@@ -207,6 +207,13 @@ Focused commands belong in Issue/PR evidence; final evidence must come from comp
 - Client suite: **11 tests passed total** = 6 Feature 12 requester-selection tests + 2 Requester API shape tests + 3 Lab 1 regression tests updated for the Lab 2 route guard.
 - `npm run build` from `client/`: **passed**.
 - Coverage includes route guard, active Requester loading/empty/failure states, disabled Continue, response-shape validation, sessionStorage restore, current identity, Change Requester A→B revalidation, and unavailable navigation placeholders.
+
+### Feature 13 Evidence
+
+- Client suite: **18 tests passed total** = 7 Feature 13 Create Ticket tests + 6 Feature 12 requester-selection tests + 2 Requester API shape tests + 3 Lab 1 regression tests.
+- `npm test` from `client/`: **passed** (4 test files, 18 tests).
+- `npm run build` from `client/`: **passed**.
+- Coverage includes active Category/Related System loading, read-only Ticket fields, default Medium priority, field-level validation and first-invalid focus, authoritative Ticket Number, busy/duplicate-submit protection, safe create failure with retry, per-file Attachment validation/removal, invalid-file exclusion, and retryable partial Attachment failure.
 
 ## 10. Known Limitations and Deferred Tests
 

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -210,10 +210,10 @@ Focused commands belong in Issue/PR evidence; final evidence must come from comp
 
 ### Feature 13 Evidence
 
-- Client suite: **22 tests passed total** = 11 Feature 13 Create Ticket tests + 6 Feature 12 requester-selection tests + 2 Requester API shape tests + 3 Lab 1 regression tests.
-- `npm test` from `client/`: **passed** (4 test files, 22 tests).
+- Client suite: **24 tests passed total** = 13 Feature 13 Create Ticket tests + 6 Feature 12 requester-selection tests + 2 Requester API shape tests + 3 Lab 1 regression tests.
+- `npm test` from `client/`: **passed** (4 test files, 24 tests).
 - `npm run build` from `client/`: **passed**.
-- Coverage includes active Category/Related System loading, read-only Ticket fields, default Medium priority, field-level validation and first-invalid focus, authoritative Ticket Number, busy/duplicate-submit protection, stable clientRequestId across create retry, safe create failure with retained files, cumulative picker/quota behavior, per-file Attachment validation/removal, invalid-file exclusion, and individual retry for partial Attachment failure.
+- Coverage includes active Category/Related System loading, read-only Ticket fields, default Medium priority, field-level validation and first-invalid focus, authoritative Ticket Number, busy/duplicate-submit protection, stable clientRequestId across create retry, fresh clientRequestId for a new Ticket, safe create failure with retained files, cumulative picker/quota behavior, extension/MIME validation, per-file Attachment validation/removal, invalid-file exclusion, and individual retry for partial Attachment failure.
 
 ## 10. Known Limitations and Deferred Tests
 

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -210,10 +210,10 @@ Focused commands belong in Issue/PR evidence; final evidence must come from comp
 
 ### Feature 13 Evidence
 
-- Client suite: **18 tests passed total** = 7 Feature 13 Create Ticket tests + 6 Feature 12 requester-selection tests + 2 Requester API shape tests + 3 Lab 1 regression tests.
-- `npm test` from `client/`: **passed** (4 test files, 18 tests).
+- Client suite: **22 tests passed total** = 11 Feature 13 Create Ticket tests + 6 Feature 12 requester-selection tests + 2 Requester API shape tests + 3 Lab 1 regression tests.
+- `npm test` from `client/`: **passed** (4 test files, 22 tests).
 - `npm run build` from `client/`: **passed**.
-- Coverage includes active Category/Related System loading, read-only Ticket fields, default Medium priority, field-level validation and first-invalid focus, authoritative Ticket Number, busy/duplicate-submit protection, safe create failure with retry, per-file Attachment validation/removal, invalid-file exclusion, and retryable partial Attachment failure.
+- Coverage includes active Category/Related System loading, read-only Ticket fields, default Medium priority, field-level validation and first-invalid focus, authoritative Ticket Number, busy/duplicate-submit protection, stable clientRequestId across create retry, safe create failure with retained files, cumulative picker/quota behavior, per-file Attachment validation/removal, invalid-file exclusion, and individual retry for partial Attachment failure.
 
 ## 10. Known Limitations and Deferred Tests
 


### PR DESCRIPTION
Closes #28 

## Summary

Implements the Lab 2 Create Ticket UI for the selected Development Requester.

## Changes

- Added Category and Related System reference-data loading
- Added read-only Ticket Number, Ticket Date, and Requester fields
- Added Summary, Description, and Requested Priority inputs
- Added client-side validation and first-invalid focus
- Added Ticket creation with clientRequestId
- Added Attachment selection, validation, removal, and upload
- Added safe create failure and retry states
- Added partial Attachment failure and retry handling
- Added Feature 13 UI tests

## Verification

- Client tests: 18 passed
- Client production build: passed
- Base branch: lab2-staging