### PR TITLE
Feature 15: Implement Requester Ticket Detail screen

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -90,8 +90,28 @@ nav a:hover { text-decoration: underline; }
 .pagination { align-items: center; justify-content: center; margin-top: 20px; color: var(--color-text-muted); }
 .pagination .button { min-width: 110px; }
 .visually-hidden { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+.detail-page { max-width: 960px; }
+.detail-heading { align-items: center; margin-top: 24px; }
+.detail-heading h1 { margin-bottom: 8px; }
+.detail-heading p:not(.eyebrow) { margin: 0; }
+.status-badge { display: inline-block; width: fit-content; padding: 3px 10px; border-radius: 999px; background: var(--color-green-pale); color: var(--color-green-primary); font-size: 13px; font-weight: 800; }
+.status-removed { background: #fff1f1; color: var(--color-error); }
+.detail-card { margin-top: 20px; padding: 24px; border: 1px solid var(--color-border); border-radius: 12px; background: #fff; }
+.detail-card h2 { margin: 0 0 18px; font-size: 22px; }
+.detail-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px 24px; margin: 0; }
+.detail-grid > div { min-width: 0; }
+.detail-grid dt { color: var(--color-text-muted); font-size: 14px; font-weight: 700; }
+.detail-grid dd { margin: 4px 0 0; overflow-wrap: anywhere; }
+.detail-wide { grid-column: 1 / -1; }
+.preserve-whitespace { white-space: pre-wrap; }
+.empty-detail { margin: 0; color: var(--color-text-muted); }
+.attachment-metadata-list { display: grid; gap: 12px; margin: 0; padding: 0; list-style: none; }
+.attachment-metadata-list li { padding: 14px; border: 1px solid var(--color-border); border-radius: 8px; background: var(--color-page); }
+.attachment-metadata-list li > div { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 14px; }
+.attachment-metadata-list li strong { flex-basis: 100%; overflow-wrap: anywhere; }
+.attachment-metadata-list li span:not(.status-badge) { color: var(--color-text-muted); font-size: 14px; }
 @media (max-width: 900px) { .ticket-filters { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 @media (max-width: 700px) { .selector-card { padding: 24px 20px; } .header-inner { align-items: flex-start; flex-direction: column; gap: 12px; } .requester-context { margin-left: 0; flex-wrap: wrap; } nav { width: 100%; } }
 @media (max-width: 760px) { .readonly-grid, .form-grid { grid-template-columns: 1fr; } .ticket-form { padding: 18px; } .form-actions { flex-direction: column-reverse; } .form-actions button { width: 100% !important; } }
-@media (max-width: 600px) { .page-heading { flex-direction: column; } .page-heading .button-primary { width: 100%; } .ticket-filters { grid-template-columns: 1fr; } .pagination { flex-wrap: wrap; } }
+@media (max-width: 600px) { .page-heading { flex-direction: column; } .page-heading .button-primary { width: 100%; } .ticket-filters { grid-template-columns: 1fr; } .pagination { flex-wrap: wrap; } .detail-card { padding: 18px; } .detail-grid { grid-template-columns: 1fr; } .detail-wide { grid-column: auto; } }
 @media (max-width: 767px) { .tickets-table-wrap { display: none; } .tickets-cards { display: block; } }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -295,7 +295,7 @@ function MyTicketsScreen({ requester, onCreate, onViewTicket, initialQuery, onQu
 }
 
 function TicketDetailScreen({ requester, ticketId, onBack }: { requester: DevelopmentRequester; ticketId: number; onBack: () => void }) {
-  const [state, setState] = useState<"loading" | "ready" | "error">("loading");
+  const [state, setState] = useState<"loading" | "ready" | "error" | "not-found">("loading");
   const [detail, setDetail] = useState<TicketDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [retryToken, setRetryToken] = useState(0);
@@ -307,7 +307,17 @@ function TicketDetailScreen({ requester, ticketId, onBack }: { requester: Develo
     setError(null);
     getTicketDetail(requester.id, ticketId)
       .then((loaded) => { if (!cancelled) { setDetail(loaded); setState("ready"); } })
-      .catch((cause) => { if (!cancelled) { setState("error"); setError(cause instanceof Error ? cause.message : "Unable to load Ticket Detail."); } });
+      .catch((cause) => {
+        if (cancelled) return;
+        const statusCode = typeof cause === "object" && cause !== null && "statusCode" in cause ? cause.statusCode : undefined;
+        if (statusCode === 404) {
+          setState("not-found");
+          setError("Ticket not found or unavailable.");
+        } else {
+          setState("error");
+          setError(cause instanceof Error ? cause.message : "Unable to load Ticket Detail.");
+        }
+      });
     return () => { cancelled = true; };
   }, [requester.id, ticketId, retryToken]);
 
@@ -319,10 +329,11 @@ function TicketDetailScreen({ requester, ticketId, onBack }: { requester: Develo
       <button type="button" className="back-button" onClick={onBack}>← Back to My Tickets</button>
       {state === "loading" && <p className="loading-message" role="status">Loading Ticket Detail…</p>}
       {state === "error" && <div className="alert alert-error" role="alert">{error ?? "Unable to load Ticket Detail."}<button type="button" className="button button-secondary retry-button" onClick={() => setRetryToken((token) => token + 1)}>Retry</button></div>}
+      {state === "not-found" && <div className="alert alert-warning" role="alert">{error ?? "Ticket not found or unavailable."}<button type="button" className="button button-secondary retry-button" onClick={() => setRetryToken((token) => token + 1)}>Retry</button></div>}
       {state === "ready" && detail && <>
         <div className="page-heading detail-heading"><div><p className="eyebrow">Requester workspace</p><h1>{detail.ticketNumber}</h1><p>Ticket Detail for {requester.name}</p></div><span className="status-badge">{detail.currentStatus}</span></div>
         <section className="detail-card" aria-labelledby="ticket-information-heading"><h2 id="ticket-information-heading">Ticket Information</h2><dl className="detail-grid"><div><dt>Ticket Number</dt><dd>{detail.ticketNumber}</dd></div><div><dt>Ticket Date</dt><dd>{formatDate(detail.ticketDate)}</dd></div><div><dt>Requester</dt><dd>{detail.requester.name} ({detail.requester.email})</dd></div><div><dt>Category</dt><dd>{detail.category.name}</dd></div><div><dt>Related System</dt><dd>{detail.relatedSystem.name}</dd></div><div><dt>Requested Priority</dt><dd>{detail.requestedPriority}</dd></div><div><dt>Current Status</dt><dd>{detail.currentStatus}</dd></div><div><dt>Last Updated</dt><dd>{formatDate(detail.updatedAt)}</dd></div><div className="detail-wide"><dt>Summary</dt><dd>{detail.summary}</dd></div><div className="detail-wide"><dt>Description</dt><dd className="preserve-whitespace">{detail.description}</dd></div></dl></section>
-        <section className="detail-card" aria-labelledby="attachment-metadata-heading"><h2 id="attachment-metadata-heading">Attachments</h2>{detail.attachments.length === 0 ? <p className="empty-detail">No Attachments on this Ticket.</p> : <ul className="attachment-metadata-list">{detail.attachments.map((attachment) => <li key={attachment.id}><div><strong>{attachment.originalName}</strong><span>{attachment.mimeType} · {formatSize(attachment.sizeBytes)}</span><span>Uploaded {formatDate(attachment.uploadedAt)}</span>{attachment.state === "REMOVED" && <span className="status-badge status-removed">Removed · {attachment.removedReason ?? "No reason provided"}</span>}{attachment.state === "ACTIVE" && <span className="status-badge">Active</span>}</div></li>)}</ul>}</section>
+        <section className="detail-card" aria-labelledby="attachment-metadata-heading"><h2 id="attachment-metadata-heading">Attachments</h2>{detail.attachments.length === 0 ? <p className="empty-detail">No Attachments on this Ticket.</p> : <ul className="attachment-metadata-list">{detail.attachments.map((attachment) => <li key={attachment.id}><div><strong>{attachment.originalName}</strong><span>{attachment.mimeType} · {formatSize(attachment.sizeBytes)}</span><span>Uploaded {formatDate(attachment.uploadedAt)}</span>{attachment.state === "REMOVED" && <><span className="status-badge status-removed">Removed · {attachment.removedReason ?? "No reason provided"}</span>{attachment.removedAt && <span>Removed at {formatDate(attachment.removedAt)}</span>}</>}{attachment.state === "ACTIVE" && <span className="status-badge">Active</span>}</div></li>)}</ul>}</section>
       </>}
     </main>
   );

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ChangeEvent, type FormEvent } from "react";
-import { createTicket, CreatedTicket, DevelopmentRequester, getCategories, getDevelopmentRequesters, getRelatedSystems, getTickets, ReferenceItem, TicketListQuery, TicketListResponse, TicketSummary, uploadTicketAttachment } from "./api.js";
+import { createTicket, CreatedTicket, DevelopmentRequester, getCategories, getDevelopmentRequesters, getRelatedSystems, getTicketDetail, getTickets, ReferenceItem, TicketDetail, TicketListQuery, TicketListResponse, TicketSummary, uploadTicketAttachment } from "./api.js";
 import "./App.css";
 
 const REQUESTER_STORAGE_KEY = "toktickit.requesterId";
@@ -228,8 +228,8 @@ function CreateTicketScreen({ requester, onBack }: CreateScreenProps) {
 
 const DEFAULT_TICKET_QUERY: TicketListQuery = { search: "", categoryId: null, relatedSystemId: null, requestedPriority: null, currentStatus: null, sortBy: "updatedAt", sortDirection: "desc", page: 1, pageSize: 10 };
 
-function MyTicketsScreen({ requester, onCreate }: { requester: DevelopmentRequester; onCreate: () => void }) {
-  const [query, setQuery] = useState(DEFAULT_TICKET_QUERY);
+function MyTicketsScreen({ requester, onCreate, onViewTicket, initialQuery, onQueryChange }: { requester: DevelopmentRequester; onCreate: () => void; onViewTicket: (ticketId: number) => void; initialQuery: TicketListQuery; onQueryChange: (query: TicketListQuery) => void }) {
+  const [query, setQueryState] = useState(initialQuery);
   const [categories, setCategories] = useState<ReferenceItem[]>([]);
   const [relatedSystems, setRelatedSystems] = useState<ReferenceItem[]>([]);
   const [data, setData] = useState<TicketListResponse | null>(null);
@@ -256,13 +256,14 @@ function MyTicketsScreen({ requester, onCreate }: { requester: DevelopmentReques
     return () => { cancelled = true; };
   }, [requester.id, query, retryToken]);
 
-  const updateQuery = (change: Partial<TicketListQuery>) => setQuery((current) => ({ ...current, ...change, page: 1 }));
-  const clearFilters = () => setQuery(DEFAULT_TICKET_QUERY);
+  const applyQuery = (next: TicketListQuery) => { setQueryState(next); onQueryChange(next); };
+  const updateQuery = (change: Partial<TicketListQuery>) => applyQuery({ ...query, ...change, page: 1 });
+  const clearFilters = () => applyQuery(DEFAULT_TICKET_QUERY);
   const hasFilters = query.search !== "" || query.categoryId !== null || query.relatedSystemId !== null || query.requestedPriority !== null || query.currentStatus !== null || query.sortBy !== "updatedAt" || query.sortDirection !== "desc" || query.pageSize !== 10;
   const formatDate = (value: string) => new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
   const sortAria = (field: TicketListQuery["sortBy"]): "ascending" | "descending" | "none" => query.sortBy === field ? (query.sortDirection === "asc" ? "ascending" : "descending") : "none";
-  const renderTicket = (ticket: TicketSummary) => <tr key={ticket.id}><td><strong>{ticket.ticketNumber}</strong></td><td>{ticket.summary}</td><td>{ticket.category.name}</td><td>{ticket.relatedSystem.name}</td><td>{ticket.requestedPriority}</td><td>{ticket.currentStatus}</td><td>{formatDate(ticket.updatedAt)}</td><td><button type="button" className="button button-secondary" disabled title="Ticket Detail is available in the next Lab 2 feature">View Ticket</button></td></tr>;
-  const renderTicketCard = (ticket: TicketSummary) => <article className="ticket-card" key={ticket.id}><h2>{ticket.ticketNumber}</h2><dl><div><dt>Summary</dt><dd>{ticket.summary}</dd></div><div><dt>Category</dt><dd>{ticket.category.name}</dd></div><div><dt>Related System</dt><dd>{ticket.relatedSystem.name}</dd></div><div><dt>Requested Priority</dt><dd>{ticket.requestedPriority}</dd></div><div><dt>Current Status</dt><dd>{ticket.currentStatus}</dd></div><div><dt>Last Updated</dt><dd>{formatDate(ticket.updatedAt)}</dd></div></dl><button type="button" className="button button-secondary" disabled title="Ticket Detail is available in the next Lab 2 feature">View Ticket</button></article>;
+  const renderTicket = (ticket: TicketSummary) => <tr key={ticket.id}><td><strong>{ticket.ticketNumber}</strong></td><td>{ticket.summary}</td><td>{ticket.category.name}</td><td>{ticket.relatedSystem.name}</td><td>{ticket.requestedPriority}</td><td>{ticket.currentStatus}</td><td>{formatDate(ticket.updatedAt)}</td><td><button type="button" className="button button-secondary" onClick={() => onViewTicket(ticket.id)}>View Ticket</button></td></tr>;
+  const renderTicketCard = (ticket: TicketSummary) => <article className="ticket-card" key={ticket.id}><h2>{ticket.ticketNumber}</h2><dl><div><dt>Summary</dt><dd>{ticket.summary}</dd></div><div><dt>Category</dt><dd>{ticket.category.name}</dd></div><div><dt>Related System</dt><dd>{ticket.relatedSystem.name}</dd></div><div><dt>Requested Priority</dt><dd>{ticket.requestedPriority}</dd></div><div><dt>Current Status</dt><dd>{ticket.currentStatus}</dd></div><div><dt>Last Updated</dt><dd>{formatDate(ticket.updatedAt)}</dd></div></dl><button type="button" className="button button-secondary" onClick={() => onViewTicket(ticket.id)}>View Ticket</button></article>;
 
   return (
     <main className="shell-content tickets-page" id="my-tickets" aria-busy={state === "loading"}>
@@ -287,14 +288,50 @@ function MyTicketsScreen({ requester, onCreate }: { requester: DevelopmentReques
         <p className="result-count" role="status">Showing {data.items.length} of {data.pagination.totalItems} Tickets</p>
         <div className="tickets-table-wrap"><table className="tickets-table"><caption className="visually-hidden">Tickets created by {requester.name}. Sorted by {query.sortBy}, {query.sortDirection === "asc" ? "ascending" : "descending"}.</caption><thead><tr><th scope="col" aria-sort={sortAria("ticketNumber")}>Ticket Number</th><th scope="col">Summary</th><th scope="col">Category</th><th scope="col">Related System</th><th scope="col">Requested Priority</th><th scope="col">Current Status</th><th scope="col" aria-sort={query.sortBy === "createdAt" ? sortAria("createdAt") : sortAria("updatedAt")}>Last Updated</th><th scope="col"><span className="visually-hidden">Actions</span></th></tr></thead><tbody>{data.items.map(renderTicket)}</tbody></table></div>
         <div className="tickets-cards" aria-label={`Tickets created by ${requester.name}`}>{data.items.map(renderTicketCard)}</div>
-        <nav className="pagination" aria-label="Ticket pagination"><button type="button" className="button button-secondary" disabled={!data.pagination.hasPreviousPage} onClick={() => setQuery((current) => ({ ...current, page: current.page - 1 }))}>Previous</button><span>Page {data.pagination.page} of {Math.max(data.pagination.totalPages, 1)}</span><button type="button" className="button button-secondary" disabled={!data.pagination.hasNextPage} onClick={() => setQuery((current) => ({ ...current, page: current.page + 1 }))}>Next</button></nav>
+        <nav className="pagination" aria-label="Ticket pagination"><button type="button" className="button button-secondary" disabled={!data.pagination.hasPreviousPage} onClick={() => applyQuery({ ...query, page: query.page - 1 })}>Previous</button><span>Page {data.pagination.page} of {Math.max(data.pagination.totalPages, 1)}</span><button type="button" className="button button-secondary" disabled={!data.pagination.hasNextPage} onClick={() => applyQuery({ ...query, page: query.page + 1 })}>Next</button></nav>
+      </>}
+    </main>
+  );
+}
+
+function TicketDetailScreen({ requester, ticketId, onBack }: { requester: DevelopmentRequester; ticketId: number; onBack: () => void }) {
+  const [state, setState] = useState<"loading" | "ready" | "error">("loading");
+  const [detail, setDetail] = useState<TicketDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [retryToken, setRetryToken] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState("loading");
+    setDetail(null);
+    setError(null);
+    getTicketDetail(requester.id, ticketId)
+      .then((loaded) => { if (!cancelled) { setDetail(loaded); setState("ready"); } })
+      .catch((cause) => { if (!cancelled) { setState("error"); setError(cause instanceof Error ? cause.message : "Unable to load Ticket Detail."); } });
+    return () => { cancelled = true; };
+  }, [requester.id, ticketId, retryToken]);
+
+  const formatDate = (value: string) => new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
+  const formatSize = (bytes: number) => bytes < 1024 * 1024 ? `${Math.ceil(bytes / 1024)} KiB` : `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+
+  return (
+    <main className="shell-content detail-page" id="ticket-detail" aria-busy={state === "loading"}>
+      <button type="button" className="back-button" onClick={onBack}>← Back to My Tickets</button>
+      {state === "loading" && <p className="loading-message" role="status">Loading Ticket Detail…</p>}
+      {state === "error" && <div className="alert alert-error" role="alert">{error ?? "Unable to load Ticket Detail."}<button type="button" className="button button-secondary retry-button" onClick={() => setRetryToken((token) => token + 1)}>Retry</button></div>}
+      {state === "ready" && detail && <>
+        <div className="page-heading detail-heading"><div><p className="eyebrow">Requester workspace</p><h1>{detail.ticketNumber}</h1><p>Ticket Detail for {requester.name}</p></div><span className="status-badge">{detail.currentStatus}</span></div>
+        <section className="detail-card" aria-labelledby="ticket-information-heading"><h2 id="ticket-information-heading">Ticket Information</h2><dl className="detail-grid"><div><dt>Ticket Number</dt><dd>{detail.ticketNumber}</dd></div><div><dt>Ticket Date</dt><dd>{formatDate(detail.ticketDate)}</dd></div><div><dt>Requester</dt><dd>{detail.requester.name} ({detail.requester.email})</dd></div><div><dt>Category</dt><dd>{detail.category.name}</dd></div><div><dt>Related System</dt><dd>{detail.relatedSystem.name}</dd></div><div><dt>Requested Priority</dt><dd>{detail.requestedPriority}</dd></div><div><dt>Current Status</dt><dd>{detail.currentStatus}</dd></div><div><dt>Last Updated</dt><dd>{formatDate(detail.updatedAt)}</dd></div><div className="detail-wide"><dt>Summary</dt><dd>{detail.summary}</dd></div><div className="detail-wide"><dt>Description</dt><dd className="preserve-whitespace">{detail.description}</dd></div></dl></section>
+        <section className="detail-card" aria-labelledby="attachment-metadata-heading"><h2 id="attachment-metadata-heading">Attachments</h2>{detail.attachments.length === 0 ? <p className="empty-detail">No Attachments on this Ticket.</p> : <ul className="attachment-metadata-list">{detail.attachments.map((attachment) => <li key={attachment.id}><div><strong>{attachment.originalName}</strong><span>{attachment.mimeType} · {formatSize(attachment.sizeBytes)}</span><span>Uploaded {formatDate(attachment.uploadedAt)}</span>{attachment.state === "REMOVED" && <span className="status-badge status-removed">Removed · {attachment.removedReason ?? "No reason provided"}</span>}{attachment.state === "ACTIVE" && <span className="status-badge">Active</span>}</div></li>)}</ul>}</section>
       </>}
     </main>
   );
 }
 
 function ApplicationShell({ requester, onChangeRequester }: { requester: DevelopmentRequester; onChangeRequester: () => void }) {
-  const [screen, setScreen] = useState<"home" | "create" | "tickets">("home");
+  const [screen, setScreen] = useState<"home" | "create" | "tickets" | "detail">("home");
+  const [selectedTicketId, setSelectedTicketId] = useState<number | null>(null);
+  const [ticketQuery, setTicketQuery] = useState(DEFAULT_TICKET_QUERY);
   return (
     <div className="app-shell">
       <header className="app-header">
@@ -302,7 +339,7 @@ function ApplicationShell({ requester, onChangeRequester }: { requester: Develop
           <a className="brand" href="#home">TokTickIT</a>
           <nav aria-label="Primary navigation">
             <a href="#home" aria-current="page">Workspace</a>
-            <button className={screen === "tickets" ? "nav-create active" : "nav-create"} type="button" onClick={() => setScreen("tickets")} aria-current={screen === "tickets" ? "page" : undefined}>My Tickets</button>
+            <button className={screen === "tickets" || screen === "detail" ? "nav-create active" : "nav-create"} type="button" onClick={() => setScreen("tickets")} aria-current={screen === "tickets" || screen === "detail" ? "page" : undefined}>My Tickets</button>
             <button className={screen === "create" ? "nav-create active" : "nav-create"} type="button" onClick={() => setScreen("create")} aria-current={screen === "create" ? "page" : undefined}>Create Ticket</button>
           </nav>
           <div className="requester-context">
@@ -311,7 +348,7 @@ function ApplicationShell({ requester, onChangeRequester }: { requester: Develop
           </div>
         </div>
       </header>
-      {screen === "create" ? <CreateTicketScreen requester={requester} onBack={() => setScreen("home")} /> : screen === "tickets" ? <MyTicketsScreen requester={requester} onCreate={() => setScreen("create")} /> : <main className="shell-content" id="home">
+      {screen === "create" ? <CreateTicketScreen requester={requester} onBack={() => setScreen("home")} /> : screen === "tickets" ? <MyTicketsScreen requester={requester} onCreate={() => setScreen("create")} onViewTicket={(ticketId) => { setSelectedTicketId(ticketId); setScreen("detail"); }} initialQuery={ticketQuery} onQueryChange={setTicketQuery} /> : screen === "detail" && selectedTicketId !== null ? <TicketDetailScreen requester={requester} ticketId={selectedTicketId} onBack={() => setScreen("tickets")} /> : <main className="shell-content" id="home">
         <p className="eyebrow">Requester workspace</p>
         <h1>Welcome to TokTickIT</h1>
         <p>Your requester context is ready. Choose an action from the navigation when the corresponding Lab 2 screen is available.</p>

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -69,6 +69,34 @@ export interface TicketListResponse {
   applied: Omit<TicketListQuery, "page" | "pageSize">;
 }
 
+export interface TicketAttachmentMetadata {
+  id: number;
+  originalName: string;
+  mimeType: string;
+  sizeBytes: number;
+  state: "ACTIVE" | "REMOVED";
+  uploadedAt: string;
+  removedAt: string | null;
+  removedReason: string | null;
+  downloadUrl: string | null;
+}
+
+export interface TicketDetail {
+  id: number;
+  ticketNumber: string;
+  ticketDate: string;
+  requester: DevelopmentRequester & { email: string };
+  category: ReferenceItem;
+  relatedSystem: ReferenceItem;
+  summary: string;
+  requestedPriority: CreateTicketInput["requestedPriority"];
+  description: string;
+  currentStatus: string;
+  createdAt: string;
+  updatedAt: string;
+  attachments: TicketAttachmentMetadata[];
+}
+
 export interface ApiValidationError extends Error {
   fieldErrors?: Record<string, string[]>;
 }
@@ -159,6 +187,18 @@ export async function getTickets(requesterId: number, query: TicketListQuery): P
   const value = await response.json() as TicketListResponse;
   if (!value || !Array.isArray(value.items) || !value.pagination || typeof value.pagination.totalItems !== "number") {
     throw new Error("TokTickIT API returned invalid Ticket list data");
+  }
+  return value;
+}
+
+export async function getTicketDetail(requesterId: number, ticketId: number): Promise<TicketDetail> {
+  const response = await fetch(`${API_URL}/api/tickets/${ticketId}`, {
+    headers: { "X-Requester-Id": String(requesterId) },
+  });
+  if (!response.ok) return throwApiError(response, "Unable to load Ticket Detail");
+  const value = await response.json() as TicketDetail;
+  if (!value || typeof value.id !== "number" || typeof value.ticketNumber !== "string" || !value.requester || !value.category || !value.relatedSystem || typeof value.summary !== "string" || typeof value.description !== "string" || !Array.isArray(value.attachments)) {
+    throw new Error("TokTickIT API returned invalid Ticket Detail data");
   }
   return value;
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -98,6 +98,7 @@ export interface TicketDetail {
 }
 
 export interface ApiValidationError extends Error {
+  statusCode?: number;
   fieldErrors?: Record<string, string[]>;
 }
 
@@ -153,6 +154,7 @@ export async function getDevelopmentRequesters(): Promise<DevelopmentRequester[]
 async function throwApiError(response: Response, fallback: string): Promise<never> {
   const body = await response.json().catch(() => null) as { error?: { message?: string; fieldErrors?: Record<string, string[]> } } | null;
   const error = new Error(body?.error?.message ?? fallback) as ApiValidationError;
+  error.statusCode = response.status;
   error.fieldErrors = body?.error?.fieldErrors;
   throw error;
 }

--- a/client/tests/lab-02/MyTickets.test.tsx
+++ b/client/tests/lab-02/MyTickets.test.tsx
@@ -47,7 +47,7 @@ describe("My Tickets screen", () => {
     expect(within(table).getByText("TKT-2026-000042")).toBeInTheDocument();
     expect(within(table).getByText("Laptop battery issue")).toBeInTheDocument();
     expect(within(table).getByRole("columnheader", { name: "Ticket Number" })).toBeInTheDocument();
-    expect(within(table).getByRole("button", { name: "View Ticket" })).toBeDisabled();
+    expect(within(table).getByRole("button", { name: "View Ticket" })).toBeEnabled();
     expect(within(table).getByRole("columnheader", { name: "Last Updated" })).toHaveAttribute("aria-sort", "descending");
     expect(document.querySelector(".tickets-cards .ticket-card")).toHaveTextContent("TKT-2026-000042");
     expect(document.querySelector(".tickets-cards .ticket-card")).toHaveTextContent("View Ticket");

--- a/client/tests/lab-02/RequesterTicketDetail.test.tsx
+++ b/client/tests/lab-02/RequesterTicketDetail.test.tsx
@@ -29,12 +29,11 @@ const listResponse: api.TicketListResponse = {
   applied: { search: "", categoryId: null, relatedSystemId: null, requestedPriority: null, currentStatus: null, sortBy: "updatedAt", sortDirection: "desc" },
 };
 
-async function renderDetail(getDetail = vi.spyOn(api, "getTicketDetail").mockResolvedValue(ticket), waitForScreen = true) {
+async function renderDetail(getDetail = vi.spyOn(api, "getTicketDetail").mockResolvedValue(ticket), waitForScreen = true, getTickets = vi.spyOn(api, "getTickets").mockResolvedValue(listResponse)) {
   sessionStorage.setItem("toktickit.requesterId", "1");
   vi.spyOn(api, "getDevelopmentRequesters").mockResolvedValue([requester]);
   vi.spyOn(api, "getCategories").mockResolvedValue([ticket.category]);
   vi.spyOn(api, "getRelatedSystems").mockResolvedValue([ticket.relatedSystem]);
-  vi.spyOn(api, "getTickets").mockResolvedValue(listResponse);
   render(<App />);
   await screen.findByText("Requester: Alice Requester");
   fireEvent.click(screen.getByRole("button", { name: "My Tickets" }));
@@ -60,6 +59,7 @@ describe("Requester Ticket Detail screen", () => {
     expect(screen.getByText("old-photo.jpg")).toBeInTheDocument();
     expect(screen.getByText(/Duplicate file/)).toBeInTheDocument();
     expect(screen.getByText("Removed · Duplicate file")).toBeInTheDocument();
+    expect(screen.getByText(/Removed at/)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Download" })).not.toBeInTheDocument();
     expect(getDetail).toHaveBeenCalledWith(1, 42);
   });
@@ -94,12 +94,37 @@ describe("Requester Ticket Detail screen", () => {
     expect(getDetail).toHaveBeenCalledTimes(2);
   });
 
+  it("shows a safe not-found state for a missing or non-owned Ticket", async () => {
+    const notFound = Object.assign(new Error("Ticket not found."), { statusCode: 404 });
+    const getDetail = vi.spyOn(api, "getTicketDetail").mockRejectedValue(notFound);
+    await renderDetail(getDetail, false);
+    expect(await screen.findByRole("alert")).toHaveTextContent("Ticket not found or unavailable.");
+    expect(screen.queryByText(ticket.ticketNumber)).not.toBeInTheDocument();
+    expect(screen.queryByText(ticket.summary)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+
   it("returns to My Tickets with the previous list query preserved", async () => {
-    await renderDetail();
+    const getTickets = vi.spyOn(api, "getTickets").mockImplementation(async (_requesterId, query) => ({
+      ...listResponse,
+      pagination: { ...listResponse.pagination, page: query.page, pageSize: query.pageSize },
+      applied: { ...listResponse.applied, search: query.search, requestedPriority: query.requestedPriority },
+    }));
+    await renderDetail(undefined, true, getTickets);
+    fireEvent.click(screen.getByRole("button", { name: "← Back to My Tickets" }));
+    await screen.findByRole("heading", { name: "My Tickets" });
+    fireEvent.change(screen.getByLabelText("Search"), { target: { value: "battery" } });
+    fireEvent.change(screen.getByLabelText("Requested Priority"), { target: { value: "HIGH" } });
+    fireEvent.change(screen.getByLabelText("Page size"), { target: { value: "20" } });
+    await waitFor(() => expect(getTickets).toHaveBeenLastCalledWith(1, expect.objectContaining({ search: "battery", requestedPriority: "HIGH", page: 1, pageSize: 20 })));
+    fireEvent.click(within(await screen.findByRole("table")).getByRole("button", { name: "View Ticket" }));
     await screen.findByRole("heading", { name: ticket.ticketNumber });
     fireEvent.click(screen.getByRole("button", { name: "← Back to My Tickets" }));
     await screen.findByRole("heading", { name: "My Tickets" });
-    expect(screen.getByLabelText("Search")).toHaveValue("");
+    expect(screen.getByLabelText("Search")).toHaveValue("battery");
+    expect(screen.getByLabelText("Requested Priority")).toHaveValue("HIGH");
+    expect(screen.getByLabelText("Page size")).toHaveValue("20");
+    expect(getTickets).toHaveBeenLastCalledWith(1, expect.objectContaining({ search: "battery", requestedPriority: "HIGH", page: 1, pageSize: 20 }));
     expect(within(await screen.findByRole("table")).getByText(ticket.ticketNumber)).toBeInTheDocument();
   });
 });

--- a/client/tests/lab-02/RequesterTicketDetail.test.tsx
+++ b/client/tests/lab-02/RequesterTicketDetail.test.tsx
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import App from "../../src/App.js";
+import * as api from "../../src/api.js";
+
+const requester = { id: 1, name: "Alice Requester" };
+const ticket = {
+  id: 42,
+  ticketNumber: "TKT-2026-000042",
+  ticketDate: "2026-08-31T10:00:00.000Z",
+  requester: { id: 1, name: "Alice Requester", email: "alice@example.com" },
+  category: { id: 1, name: "Hardware" },
+  relatedSystem: { id: 1, name: "Corporate Laptop" },
+  summary: "Laptop battery issue",
+  requestedPriority: "HIGH" as const,
+  description: "Battery drains quickly\nOccurs during normal use.",
+  currentStatus: "NEW",
+  createdAt: "2026-08-31T10:00:00.000Z",
+  updatedAt: "2026-08-31T10:30:00.000Z",
+  attachments: [
+    { id: 10, originalName: "battery.pdf", mimeType: "application/pdf", sizeBytes: 2048, state: "ACTIVE" as const, uploadedAt: "2026-08-31T10:05:00.000Z", removedAt: null, removedReason: null, downloadUrl: "/api/tickets/42/attachments/10/download" },
+    { id: 11, originalName: "old-photo.jpg", mimeType: "image/jpeg", sizeBytes: 4096, state: "REMOVED" as const, uploadedAt: "2026-08-31T10:06:00.000Z", removedAt: "2026-08-31T10:20:00.000Z", removedReason: "Duplicate file", downloadUrl: null },
+  ],
+};
+
+const listResponse: api.TicketListResponse = {
+  items: [{ id: 42, ticketNumber: ticket.ticketNumber, summary: ticket.summary, category: ticket.category, relatedSystem: ticket.relatedSystem, requestedPriority: ticket.requestedPriority, currentStatus: ticket.currentStatus, createdAt: ticket.createdAt, updatedAt: ticket.updatedAt }],
+  pagination: { page: 1, pageSize: 10, totalItems: 1, totalPages: 1, hasPreviousPage: false, hasNextPage: false },
+  applied: { search: "", categoryId: null, relatedSystemId: null, requestedPriority: null, currentStatus: null, sortBy: "updatedAt", sortDirection: "desc" },
+};
+
+async function renderDetail(getDetail = vi.spyOn(api, "getTicketDetail").mockResolvedValue(ticket), waitForScreen = true) {
+  sessionStorage.setItem("toktickit.requesterId", "1");
+  vi.spyOn(api, "getDevelopmentRequesters").mockResolvedValue([requester]);
+  vi.spyOn(api, "getCategories").mockResolvedValue([ticket.category]);
+  vi.spyOn(api, "getRelatedSystems").mockResolvedValue([ticket.relatedSystem]);
+  vi.spyOn(api, "getTickets").mockResolvedValue(listResponse);
+  render(<App />);
+  await screen.findByText("Requester: Alice Requester");
+  fireEvent.click(screen.getByRole("button", { name: "My Tickets" }));
+  await screen.findByRole("table");
+  fireEvent.click(within(screen.getByRole("table")).getByRole("button", { name: "View Ticket" }));
+  if (waitForScreen) await screen.findByRole("heading", { name: ticket.ticketNumber });
+  return getDetail;
+}
+
+afterEach(() => {
+  sessionStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("Requester Ticket Detail screen", () => {
+  it("loads owned read-only fields and active/removed Attachment metadata", async () => {
+    const getDetail = await renderDetail();
+    await screen.findByRole("heading", { name: ticket.ticketNumber });
+    expect(screen.getByText("Laptop battery issue")).toBeInTheDocument();
+    expect(screen.getByText((content) => content.includes("Battery drains quickly") && content.includes("Occurs during normal use."))).toBeInTheDocument();
+    expect(screen.getByText(/alice@example\.com/)).toBeInTheDocument();
+    expect(screen.getByText("battery.pdf")).toBeInTheDocument();
+    expect(screen.getByText("old-photo.jpg")).toBeInTheDocument();
+    expect(screen.getByText(/Duplicate file/)).toBeInTheDocument();
+    expect(screen.getByText("Removed · Duplicate file")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Download" })).not.toBeInTheDocument();
+    expect(getDetail).toHaveBeenCalledWith(1, 42);
+  });
+
+  it("shows labelled loading state without stale detail", async () => {
+    let resolveDetail!: (value: api.TicketDetail) => void;
+    const getDetail = vi.spyOn(api, "getTicketDetail").mockImplementation(() => new Promise((resolve) => { resolveDetail = resolve; }));
+    sessionStorage.setItem("toktickit.requesterId", "1");
+    vi.spyOn(api, "getDevelopmentRequesters").mockResolvedValue([requester]);
+    vi.spyOn(api, "getCategories").mockResolvedValue([ticket.category]);
+    vi.spyOn(api, "getRelatedSystems").mockResolvedValue([ticket.relatedSystem]);
+    vi.spyOn(api, "getTickets").mockResolvedValue(listResponse);
+    render(<App />);
+    await screen.findByText("Requester: Alice Requester");
+    fireEvent.click(screen.getByRole("button", { name: "My Tickets" }));
+    await screen.findByRole("table");
+    fireEvent.click(within(screen.getByRole("table")).getByRole("button", { name: "View Ticket" }));
+    expect(screen.getByText("Loading Ticket Detail…")).toBeInTheDocument();
+    expect(screen.getByRole("main")).toHaveAttribute("aria-busy", "true");
+    expect(screen.queryByText("Laptop battery issue")).not.toBeInTheDocument();
+    resolveDetail(ticket);
+    expect(await screen.findByText("Laptop battery issue")).toBeInTheDocument();
+    expect(getDetail).toHaveBeenCalledWith(1, 42);
+  });
+
+  it("shows a safe failure and retries the same owned Ticket", async () => {
+    const getDetail = vi.spyOn(api, "getTicketDetail").mockRejectedValueOnce(new Error("Unable to load Ticket Detail")).mockResolvedValueOnce(ticket);
+    await renderDetail(getDetail, false);
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to load Ticket Detail");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByRole("heading", { name: ticket.ticketNumber })).toBeInTheDocument();
+    expect(getDetail).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns to My Tickets with the previous list query preserved", async () => {
+    await renderDetail();
+    await screen.findByRole("heading", { name: ticket.ticketNumber });
+    fireEvent.click(screen.getByRole("button", { name: "← Back to My Tickets" }));
+    await screen.findByRole("heading", { name: "My Tickets" });
+    expect(screen.getByLabelText("Search")).toHaveValue("");
+    expect(within(await screen.findByRole("table")).getByText(ticket.ticketNumber)).toBeInTheDocument();
+  });
+});

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -224,10 +224,10 @@ Focused commands belong in Issue/PR evidence; final evidence must come from comp
 
 ### Feature 15 Evidence
 
-- Client suite: **35 tests passed total** = 4 Feature 15 Ticket Detail tests + 7 Feature 14 My Tickets tests + 13 Feature 13 Create Ticket tests + 6 Feature 12 requester-selection tests + 2 Requester API shape tests + 3 Lab 1 regression tests.
-- `npm test` from `client/`: **passed** (6 test files, 35 tests).
+- Client suite: **36 tests passed total** = 5 Feature 15 Ticket Detail tests + 7 Feature 14 My Tickets tests + 13 Feature 13 Create Ticket tests + 6 Feature 12 requester-selection tests + 2 Requester API shape tests + 3 Lab 1 regression tests.
+- `npm test` from `client/`: **passed** (6 test files, 36 tests).
 - `npm run build` from `client/`: **passed**.
-- Coverage includes View Ticket navigation, owned read-only Ticket fields, Requester context, loading/no-stale-data, safe failure/retry, active/removed Attachment metadata, no download action before Attachment UI, and back-navigation preserving My Tickets query.
+- Coverage includes View Ticket navigation, owned read-only Ticket fields, Requester context, loading/no-stale-data, safe failure/retry, safe 404 not-found handling without Ticket-data leakage, active/removed Attachment metadata with removal timestamp, no download action before Attachment UI, and back-navigation preserving non-default My Tickets query values.
 
 ## 10. Known Limitations and Deferred Tests
 

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -87,8 +87,8 @@ Database tests use a dedicated test database/schema. Attachment tests use a task
 | UI-12 | FR-16-FR-17, AC-14-AC-15 | Search/filters/Clear | Correct query/page reset/preserved controls | `client/tests/lab-02/MyTickets.test.tsx` | PASS |
 | UI-13 | FR-18-FR-19, AC-16-AC-17 | Sort/page/page size | Correct query and control states | `client/tests/lab-02/MyTickets.test.tsx` | PASS |
 | UI-14 | FR-20, AC-18-AC-19 | Loading/empty/no-results/query/failure | Distinct messages/actions | `client/tests/lab-02/MyTickets.test.tsx` | PASS |
-| UI-15 | FR-21, AC-20 | Open Ticket Detail | Correct owned route/action | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
-| UI-16 | FR-22-FR-24, AC-20-AC-21 | Read-only detail/denied state | Approved fields/metadata or safe not found | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Planned |
+| UI-15 | FR-21, AC-20 | Open Ticket Detail | View Ticket opens the owned Ticket Detail screen | `client/tests/lab-02/MyTickets.test.tsx`, `client/tests/lab-02/RequesterTicketDetail.test.tsx` | PASS |
+| UI-16 | FR-22-FR-24, AC-20-AC-21 | Read-only detail/denied state | Approved read-only fields and active/removed Attachment metadata, or safe failure | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | PASS |
 | UI-17 | FR-25-FR-26, AC-22-AC-24 | Upload/download states | Busy/success/error/active controls | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
 | UI-18 | FR-27-FR-28, AC-25-AC-26 | Removal dialog/reason/removed state | Accessible confirm; metadata; actions absent | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
 | UI-19 | FR-29, AC-27 | Removed/unauthorized/unavailable errors | Safe state; no file/action exposure | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
@@ -192,7 +192,7 @@ Focused commands belong in Issue/PR evidence; final evidence must come from comp
 
 ### Lab 2
 
-**Status:** Feature 14 My Tickets UI is implemented on branch `feature/14-lab2-my-tickets`; Ticket Detail and Attachment UI remain separate Features.
+**Status:** Feature 15 Ticket Detail UI is implemented on branch `feature/15-lab2-ticket-detail`; Attachment upload/download/removal UI remains a separate Feature.
 
 ### Feature 10 Evidence
 
@@ -221,6 +221,13 @@ Focused commands belong in Issue/PR evidence; final evidence must come from comp
 - `npm test` from `client/`: **passed** (5 test files, 31 tests).
 - `npm run build` from `client/`: **passed**.
 - Coverage includes owner-scoped Ticket loading, A→B requester switching without stale data, semantic desktop table and mobile card rendering, `aria-sort` state, labelled loading/no-stale-data state, search/filter AND query reset, clear filters, owner-empty and filtered no-results states, safe retry, page size, and pagination controls.
+
+### Feature 15 Evidence
+
+- Client suite: **35 tests passed total** = 4 Feature 15 Ticket Detail tests + 7 Feature 14 My Tickets tests + 13 Feature 13 Create Ticket tests + 6 Feature 12 requester-selection tests + 2 Requester API shape tests + 3 Lab 1 regression tests.
+- `npm test` from `client/`: **passed** (6 test files, 35 tests).
+- `npm run build` from `client/`: **passed**.
+- Coverage includes View Ticket navigation, owned read-only Ticket fields, Requester context, loading/no-stale-data, safe failure/retry, active/removed Attachment metadata, no download action before Attachment UI, and back-navigation preserving My Tickets query.
 
 ## 10. Known Limitations and Deferred Tests
 


### PR DESCRIPTION
## Related Issue

Closes #32 

## Summary

Adds the read-only Ticket Detail screen for the selected Development Requester.

## Changes

- Added `getTicketDetail()` with `X-Requester-Id`.
- Added View Ticket navigation from My Tickets.
- Added read-only Ticket and Requester fields.
- Added active/removed Attachment metadata.
- Added loading, failure, retry, and back navigation.
- Preserved My Tickets query state when returning.
- Added Feature 15 tests and updated `tests.md`.

Attachment upload/download/remove actions remain deferred to the next Feature.

## Verification

- `npm test` — 35 tests passed
- `npm run build` — passed
- `git diff --check` — passed

## Base branch

`lab2-staging`