### PR TITLE
Feature 16: Implement Attachment lifecycle UI

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -110,6 +110,22 @@ nav a:hover { text-decoration: underline; }
 .attachment-metadata-list li > div { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 14px; }
 .attachment-metadata-list li strong { flex-basis: 100%; overflow-wrap: anywhere; }
 .attachment-metadata-list li span:not(.status-badge) { color: var(--color-text-muted); font-size: 14px; }
+.attachment-section > label { margin-top: 8px; }
+.attachment-section input[type="file"] { display: block; width: 100%; margin-top: 6px; padding: 9px 12px; border: 1px solid var(--color-border); border-radius: 8px; background: #fff; color: var(--color-text); }
+.attachment-queue { display: grid; gap: 10px; margin: 16px 0; padding: 0; list-style: none; }
+.attachment-queue li { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 14px; padding: 12px; border: 1px solid var(--color-border); border-radius: 8px; background: var(--color-page); }
+.attachment-queue li strong { overflow-wrap: anywhere; }
+.attachment-queue li > span:not(.field-error):not(.attachment-actions) { color: var(--color-text-muted); font-size: 14px; }
+.attachment-actions { display: inline-flex; flex-wrap: wrap; gap: 8px; margin-left: auto; }
+.attachment-actions .button { min-height: 36px; padding: 6px 10px; font-size: 13px; }
+.attachment-section .attachment-metadata-list .attachment-actions { flex-basis: 100%; margin-left: 0; }
+.dialog-backdrop { position: fixed; inset: 0; z-index: 10; display: grid; place-items: center; padding: 20px; background: rgb(23 59 44 / 45%); }
+.remove-dialog { width: min(100%, 520px); padding: 24px; border: 1px solid var(--color-border); border-radius: 12px; background: #fff; box-shadow: 0 18px 50px rgb(23 59 44 / 25%); }
+.remove-dialog h2 { margin: 0 0 8px; font-size: 22px; }
+.remove-dialog p { color: var(--color-text-muted); }
+.remove-dialog textarea { display: block; width: 100%; min-height: 100px; margin-top: 6px; padding: 9px 12px; border: 1px solid var(--color-border); border-radius: 8px; resize: vertical; }
+.remove-dialog .form-actions { justify-content: flex-end; }
+.remove-dialog .button-primary { width: auto; }
 @media (max-width: 900px) { .ticket-filters { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 @media (max-width: 700px) { .selector-card { padding: 24px 20px; } .header-inner { align-items: flex-start; flex-direction: column; gap: 12px; } .requester-context { margin-left: 0; flex-wrap: wrap; } nav { width: 100%; } }
 @media (max-width: 760px) { .readonly-grid, .form-grid { grid-template-columns: 1fr; } .ticket-form { padding: 18px; } .form-actions { flex-direction: column-reverse; } .form-actions button { width: 100% !important; } }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -303,6 +303,10 @@ function attachmentQueueId(file: File): string {
   return `${file.name}-${file.size}-${file.lastModified}-${Math.random()}`;
 }
 
+function attachmentFingerprint(file: File): string {
+  return `${file.name}\u0000${file.size}\u0000${file.lastModified}`;
+}
+
 function validateAttachmentFile(file: File): string | null {
   const extension = file.name.slice(file.name.lastIndexOf(".")).toLowerCase();
   if (!attachmentRules[extension]) return "Unsupported file type. Use JPG, JPEG, PNG, WEBP, or PDF.";
@@ -328,6 +332,8 @@ function AttachmentSection({ requesterId, ticketId, attachments, onRefresh }: { 
   const [removeReason, setRemoveReason] = useState("");
   const [removeError, setRemoveError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const removeDialogRef = useRef<HTMLElement | null>(null);
+  const removeTriggerRef = useRef<HTMLButtonElement | null>(null);
   const activeCount = attachments.filter((attachment) => attachment.state === "ACTIVE").length;
 
   const formatDate = (value: string) => new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
@@ -337,8 +343,11 @@ function AttachmentSection({ requesterId, ticketId, attachments, onRefresh }: { 
     const selected = Array.from(event.target.files ?? []);
     event.target.value = "";
     let reserved = activeCount + queue.filter((item) => item.canUpload).length;
+    const fingerprints = new Set(queue.map((item) => attachmentFingerprint(item.file)));
     const next = selected.map((file): PendingAttachment => {
-      const duplicate = queue.some((item) => item.file.name === file.name && item.file.size === file.size && item.file.lastModified === file.lastModified) || attachments.some((item) => item.state === "ACTIVE" && item.originalName === file.name);
+      const fingerprint = attachmentFingerprint(file);
+      const duplicate = fingerprints.has(fingerprint);
+      if (!duplicate) fingerprints.add(fingerprint);
       const validationError = duplicate ? "This file is already selected." : validateAttachmentFile(file);
       const quotaError = !validationError && reserved >= 5 ? "Maximum 5 active Attachments reached." : null;
       if (!validationError && !quotaError) reserved += 1;
@@ -383,8 +392,28 @@ function AttachmentSection({ requesterId, ticketId, attachments, onRefresh }: { 
     }
   };
 
-  const openRemove = (attachment: TicketAttachmentMetadata) => { setRemoveTarget(attachment); setRemoveReason(""); setRemoveError(null); setActionError(null); };
-  const closeRemove = () => { if (removingId === null) { setRemoveTarget(null); setRemoveReason(""); setRemoveError(null); } };
+  const openRemove = (attachment: TicketAttachmentMetadata, trigger: HTMLButtonElement) => { removeTriggerRef.current = trigger; setRemoveTarget(attachment); setRemoveReason(""); setRemoveError(null); setActionError(null); };
+  const restoreRemoveFocus = () => { removeTriggerRef.current?.focus(); };
+  const closeRemove = () => { if (removingId === null) { setRemoveTarget(null); setRemoveReason(""); setRemoveError(null); restoreRemoveFocus(); } };
+
+  useEffect(() => {
+    if (!removeTarget || !removeDialogRef.current) return;
+    const dialog = removeDialogRef.current;
+    const focusable = () => Array.from(dialog.querySelectorAll<HTMLElement>("button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex=\"-1\"])"));
+    dialog.querySelector<HTMLElement>("#remove-reason")?.focus();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") { event.preventDefault(); closeRemove(); return; }
+      if (event.key !== "Tab") return;
+      const elements = focusable();
+      if (elements.length === 0) return;
+      const first = elements[0];
+      const last = elements[elements.length - 1];
+      if (event.shiftKey && document.activeElement === first) { event.preventDefault(); last.focus(); }
+      else if (!event.shiftKey && document.activeElement === last) { event.preventDefault(); first.focus(); }
+    };
+    dialog.addEventListener("keydown", onKeyDown);
+    return () => dialog.removeEventListener("keydown", onKeyDown);
+  }, [removeTarget, removingId]);
   const confirmRemove = async () => {
     if (!removeTarget) return;
     const trimmed = removeReason.trim();
@@ -395,6 +424,7 @@ function AttachmentSection({ requesterId, ticketId, attachments, onRefresh }: { 
       await removeTicketAttachment(requesterId, ticketId, removeTarget.id, trimmed);
       setRemoveTarget(null);
       setRemoveReason("");
+      restoreRemoveFocus();
       onRefresh();
     } catch (cause) {
       setActionError(formatAttachmentError(cause, "Unable to remove Attachment."));
@@ -408,8 +438,8 @@ function AttachmentSection({ requesterId, ticketId, attachments, onRefresh }: { 
     {actionError && <div className="alert alert-error" role="alert">{actionError}</div>}
     <label htmlFor="detail-attachments">Add Attachment<input id="detail-attachments" type="file" accept=".jpg,.jpeg,.png,.webp,.pdf" multiple onChange={selectFiles} /><small>JPG, JPEG, PNG, WEBP, or PDF; maximum 5 MiB each; maximum 5 active files</small></label>
     {queue.length > 0 && <ul className="attachment-queue" aria-label="Pending Attachments">{queue.map((item) => <li key={item.id}><strong>{item.file.name}</strong><span>{formatSize(item.file.size)}</span>{item.status === "uploading" && <span role="status">Uploading…</span>}{item.error && <span className="field-error">{item.error}</span>}<span className="attachment-actions">{item.canUpload && item.status !== "uploading" && <button type="button" className="button button-secondary" onClick={() => upload(item)}>{item.status === "error" ? "Retry" : "Upload"}</button>}<button type="button" className="file-remove" onClick={() => removeQueued(item.id)} disabled={item.status === "uploading"}>Remove</button></span></li>)}</ul>}
-    {attachments.length === 0 ? <p className="empty-detail">No Attachments on this Ticket.</p> : <ul className="attachment-metadata-list">{attachments.map((attachment) => <li key={attachment.id}><div><strong>{attachment.originalName}</strong><span>{attachment.mimeType} · {formatSize(attachment.sizeBytes)}</span><span>Uploaded {formatDate(attachment.uploadedAt)}</span>{attachment.state === "REMOVED" ? <><span className="status-badge status-removed">Removed · {attachment.removedReason ?? "No reason provided"}</span>{attachment.removedAt && <span>Removed at {formatDate(attachment.removedAt)}</span>}</> : <><span className="status-badge">Active</span><span className="attachment-actions"><button type="button" className="button button-secondary" onClick={() => download(attachment)} disabled={downloadingId === attachment.id}>{downloadingId === attachment.id ? "Downloading…" : "Download"}</button><button type="button" className="button button-secondary" onClick={() => openRemove(attachment)}>Remove</button></span></>}</div></li>)}</ul>}
-    {removeTarget && <div className="dialog-backdrop"><section className="remove-dialog" role="dialog" aria-modal="true" aria-labelledby="remove-dialog-heading"><h2 id="remove-dialog-heading">Remove {removeTarget.originalName}?</h2><p>This will hide the file while retaining its metadata.</p><label htmlFor="remove-reason">Reason<textarea id="remove-reason" value={removeReason} minLength={5} maxLength={250} autoFocus onChange={(event) => setRemoveReason(event.target.value)} aria-invalid={removeError ? "true" : "false"} /></label>{removeError && <p className="field-error" role="alert">{removeError}</p>}<div className="form-actions"><button type="button" className="button button-secondary" onClick={closeRemove} disabled={removingId !== null}>Cancel</button><button type="button" className="button button-primary remove-confirm" onClick={confirmRemove} disabled={removingId !== null}>{removingId !== null ? "Removing…" : "Confirm removal"}</button></div></section></div>}
+    {attachments.length === 0 ? <p className="empty-detail">No Attachments on this Ticket.</p> : <ul className="attachment-metadata-list">{attachments.map((attachment) => <li key={attachment.id}><div><strong>{attachment.originalName}</strong><span>{attachment.mimeType} · {formatSize(attachment.sizeBytes)}</span><span>Uploaded {formatDate(attachment.uploadedAt)}</span>{attachment.state === "REMOVED" ? <><span className="status-badge status-removed">Removed · {attachment.removedReason ?? "No reason provided"}</span>{attachment.removedAt && <span>Removed at {formatDate(attachment.removedAt)}</span>}</> : <><span className="status-badge">Active</span><span className="attachment-actions"><button type="button" className="button button-secondary" onClick={() => download(attachment)} disabled={downloadingId === attachment.id}>{downloadingId === attachment.id ? "Downloading…" : "Download"}</button><button type="button" className="button button-secondary" onClick={(event) => openRemove(attachment, event.currentTarget)}>Remove</button></span></>}</div></li>)}</ul>}
+    {removeTarget && <div className="dialog-backdrop"><section ref={removeDialogRef} className="remove-dialog" role="dialog" aria-modal="true" aria-labelledby="remove-dialog-heading"><h2 id="remove-dialog-heading">Remove {removeTarget.originalName}?</h2><p>This will hide the file while retaining its metadata.</p><label htmlFor="remove-reason">Reason<textarea id="remove-reason" value={removeReason} minLength={5} maxLength={250} onChange={(event) => setRemoveReason(event.target.value)} aria-invalid={removeError ? "true" : "false"} /></label>{removeError && <p className="field-error" role="alert">{removeError}</p>}<div className="form-actions"><button type="button" className="button button-secondary" onClick={closeRemove} disabled={removingId !== null}>Cancel</button><button type="button" className="button button-primary remove-confirm" onClick={confirmRemove} disabled={removingId !== null}>{removingId !== null ? "Removing…" : "Confirm removal"}</button></div></section></div>}
   </section>;
 }
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ChangeEvent, type FormEvent } from "react";
-import { createTicket, CreatedTicket, DevelopmentRequester, getCategories, getDevelopmentRequesters, getRelatedSystems, getTicketDetail, getTickets, ReferenceItem, TicketDetail, TicketListQuery, TicketListResponse, TicketSummary, uploadTicketAttachment } from "./api.js";
+import { createTicket, CreatedTicket, DevelopmentRequester, downloadTicketAttachment, getCategories, getDevelopmentRequesters, getRelatedSystems, getTicketDetail, getTickets, ReferenceItem, removeTicketAttachment, TicketAttachmentMetadata, TicketDetail, TicketListQuery, TicketListResponse, TicketSummary, uploadTicketAttachment } from "./api.js";
 import "./App.css";
 
 const REQUESTER_STORAGE_KEY = "toktickit.requesterId";
@@ -294,6 +294,125 @@ function MyTicketsScreen({ requester, onCreate, onViewTicket, initialQuery, onQu
   );
 }
 
+type PendingAttachment = { id: string; file: File; status: "queued" | "uploading" | "error"; error: string | null; canUpload: boolean };
+
+const attachmentRules: Record<string, string> = { ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".png": "image/png", ".webp": "image/webp", ".pdf": "application/pdf" };
+
+function attachmentQueueId(file: File): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") return crypto.randomUUID();
+  return `${file.name}-${file.size}-${file.lastModified}-${Math.random()}`;
+}
+
+function validateAttachmentFile(file: File): string | null {
+  const extension = file.name.slice(file.name.lastIndexOf(".")).toLowerCase();
+  if (!attachmentRules[extension]) return "Unsupported file type. Use JPG, JPEG, PNG, WEBP, or PDF.";
+  if (file.type !== attachmentRules[extension]) return "File extension and MIME type do not match.";
+  if (file.size > 5 * 1024 * 1024) return "File exceeds the 5 MiB limit.";
+  return null;
+}
+
+function formatAttachmentError(cause: unknown, fallback: string): string {
+  const statusCode = typeof cause === "object" && cause !== null && "statusCode" in cause ? cause.statusCode : undefined;
+  if (statusCode === 409) return "Maximum 5 active Attachments reached.";
+  if (statusCode === 413) return "File exceeds the 5 MiB limit.";
+  if (statusCode === 415) return "Unsupported Attachment type.";
+  if (statusCode === 500) return "File temporarily unavailable.";
+  return cause instanceof Error ? cause.message : fallback;
+}
+
+function AttachmentSection({ requesterId, ticketId, attachments, onRefresh }: { requesterId: number; ticketId: number; attachments: TicketAttachmentMetadata[]; onRefresh: () => void }) {
+  const [queue, setQueue] = useState<PendingAttachment[]>([]);
+  const [downloadingId, setDownloadingId] = useState<number | null>(null);
+  const [removingId, setRemovingId] = useState<number | null>(null);
+  const [removeTarget, setRemoveTarget] = useState<TicketAttachmentMetadata | null>(null);
+  const [removeReason, setRemoveReason] = useState("");
+  const [removeError, setRemoveError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const activeCount = attachments.filter((attachment) => attachment.state === "ACTIVE").length;
+
+  const formatDate = (value: string) => new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
+  const formatSize = (bytes: number) => bytes < 1024 * 1024 ? `${Math.ceil(bytes / 1024)} KiB` : `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+
+  const selectFiles = (event: ChangeEvent<HTMLInputElement>) => {
+    const selected = Array.from(event.target.files ?? []);
+    event.target.value = "";
+    let reserved = activeCount + queue.filter((item) => item.canUpload).length;
+    const next = selected.map((file): PendingAttachment => {
+      const duplicate = queue.some((item) => item.file.name === file.name && item.file.size === file.size && item.file.lastModified === file.lastModified) || attachments.some((item) => item.state === "ACTIVE" && item.originalName === file.name);
+      const validationError = duplicate ? "This file is already selected." : validateAttachmentFile(file);
+      const quotaError = !validationError && reserved >= 5 ? "Maximum 5 active Attachments reached." : null;
+      if (!validationError && !quotaError) reserved += 1;
+      const error = validationError ?? quotaError;
+      return { id: attachmentQueueId(file), file, status: error ? "error" as const : "queued" as const, error, canUpload: !error };
+    });
+    setQueue((current) => [...current, ...next]);
+  };
+
+  const removeQueued = (id: string) => setQueue((current) => current.filter((item) => item.id !== id));
+
+  const upload = async (item: PendingAttachment) => {
+    if (!item.canUpload || item.status === "uploading") return;
+    setActionError(null);
+    setQueue((current) => current.map((entry) => entry.id === item.id ? { ...entry, status: "uploading", error: null } : entry));
+    try {
+      await uploadTicketAttachment(requesterId, ticketId, item.file);
+      setQueue((current) => current.filter((entry) => entry.id !== item.id));
+      onRefresh();
+    } catch (cause) {
+      setQueue((current) => current.map((entry) => entry.id === item.id ? { ...entry, status: "error", error: formatAttachmentError(cause, "Unable to upload Attachment.") } : entry));
+    }
+  };
+
+  const download = async (attachment: TicketAttachmentMetadata) => {
+    setActionError(null);
+    setDownloadingId(attachment.id);
+    try {
+      const blob = await downloadTicketAttachment(requesterId, ticketId, attachment.id);
+      const objectUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = objectUrl;
+      anchor.download = attachment.originalName;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(objectUrl);
+    } catch (cause) {
+      setActionError(formatAttachmentError(cause, "Unable to download Attachment."));
+    } finally {
+      setDownloadingId(null);
+    }
+  };
+
+  const openRemove = (attachment: TicketAttachmentMetadata) => { setRemoveTarget(attachment); setRemoveReason(""); setRemoveError(null); setActionError(null); };
+  const closeRemove = () => { if (removingId === null) { setRemoveTarget(null); setRemoveReason(""); setRemoveError(null); } };
+  const confirmRemove = async () => {
+    if (!removeTarget) return;
+    const trimmed = removeReason.trim();
+    if (trimmed.length < 5 || trimmed.length > 250) { setRemoveError("Reason must be between 5 and 250 characters."); return; }
+    setRemovingId(removeTarget.id);
+    setRemoveError(null);
+    try {
+      await removeTicketAttachment(requesterId, ticketId, removeTarget.id, trimmed);
+      setRemoveTarget(null);
+      setRemoveReason("");
+      onRefresh();
+    } catch (cause) {
+      setActionError(formatAttachmentError(cause, "Unable to remove Attachment."));
+    } finally {
+      setRemovingId(null);
+    }
+  };
+
+  return <section className="detail-card attachment-section" aria-labelledby="attachment-heading">
+    <h2 id="attachment-heading">Attachments</h2>
+    {actionError && <div className="alert alert-error" role="alert">{actionError}</div>}
+    <label htmlFor="detail-attachments">Add Attachment<input id="detail-attachments" type="file" accept=".jpg,.jpeg,.png,.webp,.pdf" multiple onChange={selectFiles} /><small>JPG, JPEG, PNG, WEBP, or PDF; maximum 5 MiB each; maximum 5 active files</small></label>
+    {queue.length > 0 && <ul className="attachment-queue" aria-label="Pending Attachments">{queue.map((item) => <li key={item.id}><strong>{item.file.name}</strong><span>{formatSize(item.file.size)}</span>{item.status === "uploading" && <span role="status">Uploading…</span>}{item.error && <span className="field-error">{item.error}</span>}<span className="attachment-actions">{item.canUpload && item.status !== "uploading" && <button type="button" className="button button-secondary" onClick={() => upload(item)}>{item.status === "error" ? "Retry" : "Upload"}</button>}<button type="button" className="file-remove" onClick={() => removeQueued(item.id)} disabled={item.status === "uploading"}>Remove</button></span></li>)}</ul>}
+    {attachments.length === 0 ? <p className="empty-detail">No Attachments on this Ticket.</p> : <ul className="attachment-metadata-list">{attachments.map((attachment) => <li key={attachment.id}><div><strong>{attachment.originalName}</strong><span>{attachment.mimeType} · {formatSize(attachment.sizeBytes)}</span><span>Uploaded {formatDate(attachment.uploadedAt)}</span>{attachment.state === "REMOVED" ? <><span className="status-badge status-removed">Removed · {attachment.removedReason ?? "No reason provided"}</span>{attachment.removedAt && <span>Removed at {formatDate(attachment.removedAt)}</span>}</> : <><span className="status-badge">Active</span><span className="attachment-actions"><button type="button" className="button button-secondary" onClick={() => download(attachment)} disabled={downloadingId === attachment.id}>{downloadingId === attachment.id ? "Downloading…" : "Download"}</button><button type="button" className="button button-secondary" onClick={() => openRemove(attachment)}>Remove</button></span></>}</div></li>)}</ul>}
+    {removeTarget && <div className="dialog-backdrop"><section className="remove-dialog" role="dialog" aria-modal="true" aria-labelledby="remove-dialog-heading"><h2 id="remove-dialog-heading">Remove {removeTarget.originalName}?</h2><p>This will hide the file while retaining its metadata.</p><label htmlFor="remove-reason">Reason<textarea id="remove-reason" value={removeReason} minLength={5} maxLength={250} autoFocus onChange={(event) => setRemoveReason(event.target.value)} aria-invalid={removeError ? "true" : "false"} /></label>{removeError && <p className="field-error" role="alert">{removeError}</p>}<div className="form-actions"><button type="button" className="button button-secondary" onClick={closeRemove} disabled={removingId !== null}>Cancel</button><button type="button" className="button button-primary remove-confirm" onClick={confirmRemove} disabled={removingId !== null}>{removingId !== null ? "Removing…" : "Confirm removal"}</button></div></section></div>}
+  </section>;
+}
+
 function TicketDetailScreen({ requester, ticketId, onBack }: { requester: DevelopmentRequester; ticketId: number; onBack: () => void }) {
   const [state, setState] = useState<"loading" | "ready" | "error" | "not-found">("loading");
   const [detail, setDetail] = useState<TicketDetail | null>(null);
@@ -333,7 +452,7 @@ function TicketDetailScreen({ requester, ticketId, onBack }: { requester: Develo
       {state === "ready" && detail && <>
         <div className="page-heading detail-heading"><div><p className="eyebrow">Requester workspace</p><h1>{detail.ticketNumber}</h1><p>Ticket Detail for {requester.name}</p></div><span className="status-badge">{detail.currentStatus}</span></div>
         <section className="detail-card" aria-labelledby="ticket-information-heading"><h2 id="ticket-information-heading">Ticket Information</h2><dl className="detail-grid"><div><dt>Ticket Number</dt><dd>{detail.ticketNumber}</dd></div><div><dt>Ticket Date</dt><dd>{formatDate(detail.ticketDate)}</dd></div><div><dt>Requester</dt><dd>{detail.requester.name} ({detail.requester.email})</dd></div><div><dt>Category</dt><dd>{detail.category.name}</dd></div><div><dt>Related System</dt><dd>{detail.relatedSystem.name}</dd></div><div><dt>Requested Priority</dt><dd>{detail.requestedPriority}</dd></div><div><dt>Current Status</dt><dd>{detail.currentStatus}</dd></div><div><dt>Last Updated</dt><dd>{formatDate(detail.updatedAt)}</dd></div><div className="detail-wide"><dt>Summary</dt><dd>{detail.summary}</dd></div><div className="detail-wide"><dt>Description</dt><dd className="preserve-whitespace">{detail.description}</dd></div></dl></section>
-        <section className="detail-card" aria-labelledby="attachment-metadata-heading"><h2 id="attachment-metadata-heading">Attachments</h2>{detail.attachments.length === 0 ? <p className="empty-detail">No Attachments on this Ticket.</p> : <ul className="attachment-metadata-list">{detail.attachments.map((attachment) => <li key={attachment.id}><div><strong>{attachment.originalName}</strong><span>{attachment.mimeType} · {formatSize(attachment.sizeBytes)}</span><span>Uploaded {formatDate(attachment.uploadedAt)}</span>{attachment.state === "REMOVED" && <><span className="status-badge status-removed">Removed · {attachment.removedReason ?? "No reason provided"}</span>{attachment.removedAt && <span>Removed at {formatDate(attachment.removedAt)}</span>}</>}{attachment.state === "ACTIVE" && <span className="status-badge">Active</span>}</div></li>)}</ul>}</section>
+        <AttachmentSection requesterId={requester.id} ticketId={detail.id} attachments={detail.attachments} onRefresh={() => setRetryToken((token) => token + 1)} />
       </>}
     </main>
   );

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -235,5 +235,31 @@ export async function uploadTicketAttachment(requesterId: number, ticketId: numb
     body: form,
   });
   if (!response.ok) return throwApiError(response, "Unable to upload Attachment");
-  return response.json();
+  const value = await response.json() as TicketAttachmentMetadata;
+  if (!value || typeof value.id !== "number" || typeof value.originalName !== "string" || typeof value.mimeType !== "string" || typeof value.sizeBytes !== "number" || (value.state !== "ACTIVE" && value.state !== "REMOVED")) {
+    throw new Error("TokTickIT API returned invalid Attachment data");
+  }
+  return value;
+}
+
+export async function downloadTicketAttachment(requesterId: number, ticketId: number, attachmentId: number): Promise<Blob> {
+  const response = await fetch(`${API_URL}/api/tickets/${ticketId}/attachments/${attachmentId}/download`, {
+    headers: { "X-Requester-Id": String(requesterId) },
+  });
+  if (!response.ok) return throwApiError(response, "Unable to download Attachment");
+  return response.blob();
+}
+
+export async function removeTicketAttachment(requesterId: number, ticketId: number, attachmentId: number, reason: string): Promise<TicketAttachmentMetadata> {
+  const response = await fetch(`${API_URL}/api/tickets/${ticketId}/attachments/${attachmentId}`, {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json", "X-Requester-Id": String(requesterId) },
+    body: JSON.stringify({ reason }),
+  });
+  if (!response.ok) return throwApiError(response, "Unable to remove Attachment");
+  const value = await response.json() as TicketAttachmentMetadata;
+  if (!value || typeof value.id !== "number" || value.state !== "REMOVED" || value.downloadUrl !== null) {
+    throw new Error("TokTickIT API returned invalid removed Attachment data");
+  }
+  return value;
 }

--- a/client/tests/lab-02/AttachmentSection.test.tsx
+++ b/client/tests/lab-02/AttachmentSection.test.tsx
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import App from "../../src/App.js";
+import * as api from "../../src/api.js";
+
+const requester = { id: 1, name: "Alice Requester" };
+const category = { id: 1, name: "Hardware" };
+const system = { id: 1, name: "Corporate Laptop" };
+const activeAttachment: api.TicketAttachmentMetadata = { id: 10, originalName: "battery.pdf", mimeType: "application/pdf", sizeBytes: 2048, state: "ACTIVE", uploadedAt: "2026-08-31T10:05:00.000Z", removedAt: null, removedReason: null, downloadUrl: "/api/tickets/42/attachments/10/download" };
+const removedAttachment: api.TicketAttachmentMetadata = { id: 11, originalName: "old-photo.jpg", mimeType: "image/jpeg", sizeBytes: 4096, state: "REMOVED", uploadedAt: "2026-08-31T10:06:00.000Z", removedAt: "2026-08-31T10:20:00.000Z", removedReason: "Duplicate file", downloadUrl: null };
+const ticket: api.TicketDetail = { id: 42, ticketNumber: "TKT-2026-000042", ticketDate: "2026-08-31T10:00:00.000Z", requester: { ...requester, email: "alice@example.com" }, category, relatedSystem: system, summary: "Laptop battery issue", requestedPriority: "HIGH", description: "Battery drains quickly", currentStatus: "NEW", createdAt: "2026-08-31T10:00:00.000Z", updatedAt: "2026-08-31T10:30:00.000Z", attachments: [activeAttachment] };
+const listResponse: api.TicketListResponse = { items: [{ id: 42, ticketNumber: ticket.ticketNumber, summary: ticket.summary, category, relatedSystem: system, requestedPriority: ticket.requestedPriority, currentStatus: ticket.currentStatus, createdAt: ticket.createdAt, updatedAt: ticket.updatedAt }], pagination: { page: 1, pageSize: 10, totalItems: 1, totalPages: 1, hasPreviousPage: false, hasNextPage: false }, applied: { search: "", categoryId: null, relatedSystemId: null, requestedPriority: null, currentStatus: null, sortBy: "updatedAt", sortDirection: "desc" } };
+
+async function renderDetail(getDetail = vi.spyOn(api, "getTicketDetail").mockResolvedValue(ticket)) {
+  sessionStorage.setItem("toktickit.requesterId", "1");
+  vi.spyOn(api, "getDevelopmentRequesters").mockResolvedValue([requester]);
+  vi.spyOn(api, "getCategories").mockResolvedValue([category]);
+  vi.spyOn(api, "getRelatedSystems").mockResolvedValue([system]);
+  vi.spyOn(api, "getTickets").mockResolvedValue(listResponse);
+  render(<App />);
+  await screen.findByText("Requester: Alice Requester");
+  fireEvent.click(screen.getByRole("button", { name: "My Tickets" }));
+  await screen.findByRole("table");
+  fireEvent.click(within(screen.getByRole("table")).getByRole("button", { name: "View Ticket" }));
+  await screen.findByRole("heading", { name: ticket.ticketNumber });
+  return getDetail;
+}
+
+afterEach(() => { sessionStorage.clear(); vi.restoreAllMocks(); });
+
+describe("Attachment section", () => {
+  it("downloads an active owned Attachment with requester context", async () => {
+    const download = vi.spyOn(api, "downloadTicketAttachment").mockResolvedValue(new Blob(["pdf"], { type: "application/pdf" }));
+    Object.defineProperty(URL, "createObjectURL", { configurable: true, value: vi.fn(() => "blob:test") });
+    Object.defineProperty(URL, "revokeObjectURL", { configurable: true, value: vi.fn() });
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
+    await renderDetail();
+    fireEvent.click(screen.getByRole("button", { name: "Download" }));
+    await waitFor(() => expect(download).toHaveBeenCalledWith(1, 42, 10));
+  });
+
+  it("queues a valid file and refreshes authoritative metadata after upload", async () => {
+    const upload = vi.spyOn(api, "uploadTicketAttachment").mockResolvedValue({});
+    const getDetail = vi.spyOn(api, "getTicketDetail").mockResolvedValue(ticket);
+    await renderDetail(getDetail);
+    const file = new File(["pdf"], "new.pdf", { type: "application/pdf" });
+    fireEvent.change(screen.getByLabelText(/Add Attachment/), { target: { files: [file] } });
+    expect(within(screen.getByRole("list", { name: "Pending Attachments" })).getByRole("listitem")).toHaveTextContent("new.pdf");
+    fireEvent.click(screen.getByRole("button", { name: "Upload" }));
+    await waitFor(() => expect(upload).toHaveBeenCalledWith(1, 42, file));
+    await waitFor(() => expect(getDetail).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText("new.pdf")).not.toBeInTheDocument();
+  });
+
+  it("retains a failed upload with an individual Retry action", async () => {
+    const file = new File(["pdf"], "retry.pdf", { type: "application/pdf" });
+    const upload = vi.spyOn(api, "uploadTicketAttachment").mockRejectedValueOnce(new Error("Upload failed")).mockResolvedValueOnce({});
+    await renderDetail();
+    fireEvent.change(screen.getByLabelText(/Add Attachment/), { target: { files: [file] } });
+    fireEvent.click(screen.getByRole("button", { name: "Upload" }));
+    expect(await screen.findByText("Upload failed")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(upload).toHaveBeenCalledTimes(2));
+  });
+
+  it("shows invalid MIME, duplicate, and over-limit files instead of dropping them", async () => {
+    await renderDetail();
+    const input = screen.getByLabelText(/Add Attachment/);
+    fireEvent.change(input, { target: { files: [new File(["x"], "bad.txt", { type: "text/plain" }), new File(["x"], "wrong.pdf", { type: "image/png" }), new File(["x"], "battery.pdf", { type: "application/pdf" })] } });
+    expect(screen.getByText(/Unsupported file type/)).toBeInTheDocument();
+    expect(screen.getByText(/extension and MIME type/)).toBeInTheDocument();
+    expect(screen.getByText("This file is already selected.")).toBeInTheDocument();
+    expect(within(screen.getByRole("list", { name: "Pending Attachments" })).getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  it("requires a valid removal reason and soft-removes an active Attachment", async () => {
+    const remove = vi.spyOn(api, "removeTicketAttachment").mockResolvedValue({ ...activeAttachment, state: "REMOVED", removedAt: "2026-09-01T10:00:00.000Z", removedReason: "No longer needed", downloadUrl: null });
+    await renderDetail();
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Confirm removal" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("between 5 and 250");
+    fireEvent.change(screen.getByLabelText("Reason"), { target: { value: "No longer needed" } });
+    fireEvent.click(screen.getByRole("button", { name: "Confirm removal" }));
+    await waitFor(() => expect(remove).toHaveBeenCalledWith(1, 42, 10, "No longer needed"));
+  });
+
+  it("does not expose actions for removed Attachments and maps storage failures safely", async () => {
+    const getDetail = vi.spyOn(api, "getTicketDetail").mockResolvedValue({ ...ticket, attachments: [activeAttachment, removedAttachment] });
+    const download = vi.spyOn(api, "downloadTicketAttachment").mockRejectedValue(Object.assign(new Error("storage path leaked"), { statusCode: 500 }));
+    await renderDetail(getDetail);
+    expect(screen.getByText("Removed · Duplicate file")).toBeInTheDocument();
+    const removedRow = screen.getByText("old-photo.jpg").closest("li");
+    expect(removedRow).not.toBeNull();
+    expect(within(removedRow as HTMLElement).queryByRole("button", { name: "Download" })).not.toBeInTheDocument();
+    expect(within(removedRow as HTMLElement).queryByRole("button", { name: "Remove" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Download" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("File temporarily unavailable");
+    expect(download).toHaveBeenCalledWith(1, 42, 10);
+  });
+});

--- a/client/tests/lab-02/AttachmentSection.test.tsx
+++ b/client/tests/lab-02/AttachmentSection.test.tsx
@@ -66,11 +66,32 @@ describe("Attachment section", () => {
   it("shows invalid MIME, duplicate, and over-limit files instead of dropping them", async () => {
     await renderDetail();
     const input = screen.getByLabelText(/Add Attachment/);
-    fireEvent.change(input, { target: { files: [new File(["x"], "bad.txt", { type: "text/plain" }), new File(["x"], "wrong.pdf", { type: "image/png" }), new File(["x"], "battery.pdf", { type: "application/pdf" })] } });
+    const duplicateA = new File(["x"], "same.pdf", { type: "application/pdf", lastModified: 1 });
+    const duplicateB = new File(["x"], "same.pdf", { type: "application/pdf", lastModified: 1 });
+    fireEvent.change(input, { target: { files: [new File(["x"], "bad.txt", { type: "text/plain" }), new File(["x"], "wrong.pdf", { type: "image/png" }), duplicateA, duplicateB, new File(["different content"], "battery.pdf", { type: "application/pdf" })] } });
     expect(screen.getByText(/Unsupported file type/)).toBeInTheDocument();
     expect(screen.getByText(/extension and MIME type/)).toBeInTheDocument();
     expect(screen.getByText("This file is already selected.")).toBeInTheDocument();
-    expect(within(screen.getByRole("list", { name: "Pending Attachments" })).getAllByRole("listitem")).toHaveLength(3);
+    expect(within(screen.getByRole("list", { name: "Pending Attachments" })).getAllByRole("listitem")).toHaveLength(5);
+  });
+
+  it("traps focus in the removal dialog, closes on Escape, and restores the trigger focus", async () => {
+    await renderDetail();
+    const trigger = screen.getByRole("button", { name: "Remove" });
+    fireEvent.click(trigger);
+    const dialog = screen.getByRole("dialog");
+    const reason = screen.getByLabelText("Reason");
+    const confirm = screen.getByRole("button", { name: "Confirm removal" });
+    expect(document.activeElement).toBe(reason);
+    confirm.focus();
+    fireEvent.keyDown(dialog, { key: "Tab" });
+    expect(document.activeElement).toBe(reason);
+    reason.focus();
+    fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(confirm);
+    fireEvent.keyDown(dialog, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(document.activeElement).toBe(trigger);
   });
 
   it("requires a valid removal reason and soft-removes an active Attachment", async () => {
@@ -83,6 +104,32 @@ describe("Attachment section", () => {
     fireEvent.change(screen.getByLabelText("Reason"), { target: { value: "No longer needed" } });
     fireEvent.click(screen.getByRole("button", { name: "Confirm removal" }));
     await waitFor(() => expect(remove).toHaveBeenCalledWith(1, 42, 10, "No longer needed"));
+  });
+
+  it("shows Removing busy state and prevents repeated removal while the request is pending", async () => {
+    let resolveRemove!: (value: api.TicketAttachmentMetadata) => void;
+    const remove = vi.spyOn(api, "removeTicketAttachment").mockImplementation(() => new Promise((resolve) => { resolveRemove = resolve; }));
+    const getDetail = vi.spyOn(api, "getTicketDetail").mockResolvedValue(ticket);
+    await renderDetail(getDetail);
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    fireEvent.change(screen.getByLabelText("Reason"), { target: { value: "No longer needed" } });
+    fireEvent.click(screen.getByRole("button", { name: "Confirm removal" }));
+    expect(await screen.findByRole("button", { name: "Removing…" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(remove).toHaveBeenCalledTimes(1);
+    resolveRemove({ ...activeAttachment, state: "REMOVED", removedAt: "2026-09-01T10:00:00.000Z", removedReason: "No longer needed", downloadUrl: null });
+    await waitFor(() => expect(getDetail).toHaveBeenCalledTimes(2));
+  });
+
+  it("keeps a real sixth selection visible and marks it over quota when four active files already exist", async () => {
+    const fourActive: api.TicketAttachmentMetadata[] = [activeAttachment, 12, 13, 14].map((entry, index) => index === 0 ? activeAttachment : { ...activeAttachment, id: entry as number, originalName: `existing-${entry as number}.pdf` });
+    const getDetail = vi.spyOn(api, "getTicketDetail").mockResolvedValue({ ...ticket, attachments: fourActive });
+    await renderDetail(getDetail);
+    fireEvent.change(screen.getByLabelText(/Add Attachment/), { target: { files: [new File(["a"], "fifth.pdf", { type: "application/pdf" }), new File(["b"], "sixth.pdf", { type: "application/pdf" })] } });
+    const pending = screen.getByRole("list", { name: "Pending Attachments" });
+    expect(within(pending).getByText("fifth.pdf")).toBeInTheDocument();
+    expect(within(pending).getByText("sixth.pdf")).toBeInTheDocument();
+    expect(within(pending).getByText("Maximum 5 active Attachments reached.")).toBeInTheDocument();
   });
 
   it("does not expose actions for removed Attachments and maps storage failures safely", async () => {

--- a/client/tests/lab-02/RequesterTicketDetail.test.tsx
+++ b/client/tests/lab-02/RequesterTicketDetail.test.tsx
@@ -60,7 +60,9 @@ describe("Requester Ticket Detail screen", () => {
     expect(screen.getByText(/Duplicate file/)).toBeInTheDocument();
     expect(screen.getByText("Removed · Duplicate file")).toBeInTheDocument();
     expect(screen.getByText(/Removed at/)).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Download" })).not.toBeInTheDocument();
+    const removedRow = screen.getByText("old-photo.jpg").closest("li");
+    expect(removedRow).not.toBeNull();
+    expect(within(removedRow as HTMLElement).queryByRole("button", { name: "Download" })).not.toBeInTheDocument();
     expect(getDetail).toHaveBeenCalledWith(1, 42);
   });
 

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -89,9 +89,9 @@ Database tests use a dedicated test database/schema. Attachment tests use a task
 | UI-14 | FR-20, AC-18-AC-19 | Loading/empty/no-results/query/failure | Distinct messages/actions | `client/tests/lab-02/MyTickets.test.tsx` | PASS |
 | UI-15 | FR-21, AC-20 | Open Ticket Detail | View Ticket opens the owned Ticket Detail screen | `client/tests/lab-02/MyTickets.test.tsx`, `client/tests/lab-02/RequesterTicketDetail.test.tsx` | PASS |
 | UI-16 | FR-22-FR-24, AC-20-AC-21 | Read-only detail/denied state | Approved read-only fields and active/removed Attachment metadata, or safe failure | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | PASS |
-| UI-17 | FR-25-FR-26, AC-22-AC-24 | Upload/download states | Busy/success/error/active controls | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
-| UI-18 | FR-27-FR-28, AC-25-AC-26 | Removal dialog/reason/removed state | Accessible confirm; metadata; actions absent | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
-| UI-19 | FR-29, AC-27 | Removed/unauthorized/unavailable errors | Safe state; no file/action exposure | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
+| UI-17 | FR-25-FR-26, AC-22-AC-24 | Upload/download states | Busy/success/error/active controls | `client/tests/lab-02/AttachmentSection.test.tsx` | PASS |
+| UI-18 | FR-27-FR-28, AC-25-AC-26 | Removal dialog/reason/removed state | Accessible confirm; metadata; actions absent | `client/tests/lab-02/AttachmentSection.test.tsx` | PASS |
+| UI-19 | FR-29, AC-27 | Removed/unauthorized/unavailable errors | Safe state; no file/action exposure | `client/tests/lab-02/AttachmentSection.test.tsx` | PASS |
 | UI-20 | FR-30-FR-32, AC-28 | Labels/markers/field/button states | Required semantics/classes/text indicators | `client/tests/lab-02/ZenGreenStyle.test.tsx` | Planned |
 | UI-21 | AC-28 | Keyboard and automated accessibility checks | Logical focus; no serious/critical violations | `client/tests/lab-02/accessibility.test.tsx` | Planned |
 
@@ -192,7 +192,7 @@ Focused commands belong in Issue/PR evidence; final evidence must come from comp
 
 ### Lab 2
 
-**Status:** Feature 15 Ticket Detail UI is implemented on branch `feature/15-lab2-ticket-detail`; Attachment upload/download/removal UI remains a separate Feature.
+**Status:** Feature 16 Attachment UI is implemented on branch `feature/16-lab2-attachment-ui`; upload, download, soft removal, validation, retry, and safe error states are included.
 
 ### Feature 10 Evidence
 
@@ -228,6 +228,13 @@ Focused commands belong in Issue/PR evidence; final evidence must come from comp
 - `npm test` from `client/`: **passed** (6 test files, 36 tests).
 - `npm run build` from `client/`: **passed**.
 - Coverage includes View Ticket navigation, owned read-only Ticket fields, Requester context, loading/no-stale-data, safe failure/retry, safe 404 not-found handling without Ticket-data leakage, active/removed Attachment metadata with removal timestamp, no download action before Attachment UI, and back-navigation preserving non-default My Tickets query values.
+
+### Feature 16 Evidence
+
+- Client suite: **42 tests passed total** = 6 Feature 16 Attachment UI tests + 5 Feature 15 Ticket Detail tests + 7 Feature 14 My Tickets tests + 13 Feature 13 Create Ticket tests + 6 Feature 12 requester-selection tests + 2 Requester API shape tests + 3 Lab 1 regression tests.
+- `npm test` from `client/`: **passed** (7 test files, 42 tests).
+- `npm run build` from `client/`: **passed**.
+- Coverage includes active Attachment download with requester context, per-file upload success/failure/retry, cumulative client validation for MIME/type/duplicate files, accessible removal dialog with 5-250 character reason validation, removed Attachment action suppression, and safe storage-unavailable messaging.
 
 ## 10. Known Limitations and Deferred Tests
 

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -231,10 +231,10 @@ Focused commands belong in Issue/PR evidence; final evidence must come from comp
 
 ### Feature 16 Evidence
 
-- Client suite: **42 tests passed total** = 6 Feature 16 Attachment UI tests + 5 Feature 15 Ticket Detail tests + 7 Feature 14 My Tickets tests + 13 Feature 13 Create Ticket tests + 6 Feature 12 requester-selection tests + 2 Requester API shape tests + 3 Lab 1 regression tests.
-- `npm test` from `client/`: **passed** (7 test files, 42 tests).
+- Client suite: **45 tests passed total** = 9 Feature 16 Attachment UI tests + 5 Feature 15 Ticket Detail tests + 7 Feature 14 My Tickets tests + 13 Feature 13 Create Ticket tests + 6 Feature 12 requester-selection tests + 2 Requester API shape tests + 3 Lab 1 regression tests.
+- `npm test` from `client/`: **passed** (7 test files, 45 tests).
 - `npm run build` from `client/`: **passed**.
-- Coverage includes active Attachment download with requester context, per-file upload success/failure/retry, cumulative client validation for MIME/type/duplicate files, accessible removal dialog with 5-250 character reason validation, removed Attachment action suppression, and safe storage-unavailable messaging.
+- Coverage includes active Attachment download with requester context, per-file upload success/failure/retry, cumulative client validation for MIME/type/duplicate files, same-name different-content acceptance, real sixth-file quota visibility, focus trap/Escape/trigger-focus restoration, Removing busy state and duplicate activation prevention, accessible removal dialog with 5-250 character reason validation, removed Attachment action suppression, and safe storage-unavailable messaging.
 
 ## 10. Known Limitations and Deferred Tests
 


### PR DESCRIPTION
## Related Issue

Closes #34 

## Summary

Adds the Attachment lifecycle UI to the requester-owned Ticket Detail screen.

## Changes

- Added Attachment upload with client-side validation.
- Added per-file upload, retry, and remove-from-queue states.
- Added active Attachment download.
- Added accessible soft-removal dialog with reason validation.
- Added removed metadata and removal timestamp display.
- Added safe storage failure handling.
- Added Attachment UI tests and updated `docs/lab-02/tests.md`.

## Verification

- `npm test` — 42 tests passed
- `npm run build` — passed
- `git diff --check` — passed

## Base branch

`lab2-staging`