### PR TITLE
Feature 18: E2E requester and ticket creation flow

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -1,0 +1,55 @@
+name: E2E CI
+
+on:
+  pull_request:
+    branches: [main, lab2-staging]
+  push:
+    branches: [main, lab2-staging]
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: toktickit
+          POSTGRES_PASSWORD: toktickit
+          POSTGRES_DB: toktickit
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U toktickit -d toktickit"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    env:
+      DATABASE_URL: postgresql://toktickit:toktickit@localhost:5432/toktickit?schema=public
+      E2E_API_URL: http://127.0.0.1:3000
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+      - name: Install server dependencies
+        working-directory: server
+        run: npm ci
+      - name: Install client dependencies
+        working-directory: client
+        run: npm ci
+      - name: Apply migrations
+        working-directory: server
+        run: npx prisma migrate deploy
+      - name: Seed reference data
+        working-directory: server
+        run: npm run prisma:seed
+      - name: Install Playwright browser
+        working-directory: client
+        run: npx playwright install --with-deps chromium
+      - name: Run E2E tests
+        working-directory: client
+        run: npm run e2e

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -46,7 +46,9 @@ jobs:
         run: npx prisma migrate deploy
       - name: Seed reference data
         working-directory: server
-        run: npm run prisma:seed
+        run: |
+          npm run prisma:seed
+          npm run prisma:seed
       - name: Install Playwright browser
         working-directory: client
         run: npx playwright install --with-deps chromium

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ server/prisma/*.db
 # logs & OS
 *.log
 .DS_Store
+playwright-report/
+test-results/
+e2e/.tmp/

--- a/client/e2e/lab-02/requester-ticket-flow.spec.ts
+++ b/client/e2e/lab-02/requester-ticket-flow.spec.ts
@@ -14,9 +14,11 @@ async function enterRequesterWorkspace(page: Page): Promise<number> {
   await page.goto("/");
   const requesterSelect = page.locator("#requester-select");
   await expect(requesterSelect).toBeVisible();
-  await expect(requesterSelect.locator("option")).toHaveCount(5);
-  await requesterSelect.selectOption({ index: 1 });
-  const requesterId = Number(await requesterSelect.inputValue());
+  const activeRequesterOption = requesterSelect.locator('option:not([value=""])').first();
+  await expect(activeRequesterOption).toHaveCount(1);
+  const requesterId = Number(await activeRequesterOption.getAttribute("value"));
+  expect(Number.isSafeInteger(requesterId)).toBeTruthy();
+  await requesterSelect.selectOption(String(requesterId));
   await page.getByRole("button", { name: "Continue", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Welcome to TokTickIT" })).toBeVisible();
   return requesterId;

--- a/client/e2e/lab-02/requester-ticket-flow.spec.ts
+++ b/client/e2e/lab-02/requester-ticket-flow.spec.ts
@@ -1,0 +1,159 @@
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+
+const API_URL = process.env.E2E_API_URL ?? "http://127.0.0.1:3000";
+
+type TicketListItem = {
+  id: number;
+  ticketNumber: string;
+  summary: string;
+  requestedPriority: string;
+  currentStatus: string;
+};
+
+async function enterRequesterWorkspace(page: Page): Promise<number> {
+  await page.goto("/");
+  const requesterSelect = page.locator("#requester-select");
+  await expect(requesterSelect).toBeVisible();
+  await expect(requesterSelect.locator("option")).toHaveCount(5);
+  await requesterSelect.selectOption({ index: 1 });
+  const requesterId = Number(await requesterSelect.inputValue());
+  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Welcome to TokTickIT" })).toBeVisible();
+  return requesterId;
+}
+
+async function openCreateTicket(page: Page) {
+  await page.getByRole("button", { name: "Create Ticket", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Create Ticket" })).toBeVisible();
+  await expect(page.locator("#category-id")).toBeEnabled();
+  await expect(page.locator("#related-system-id")).toBeEnabled();
+}
+
+async function fillValidTicket(page: Page, summary: string) {
+  await page.locator("#category-id").selectOption({ index: 1 });
+  await page.locator("#related-system-id").selectOption({ index: 1 });
+  await page.locator("#requested-priority").selectOption("URGENT");
+  await page.locator("#summary").fill(summary);
+  await page.locator("#description").fill("End-to-end verification of the complete requester ticket workflow.");
+}
+
+async function findTicket(request: APIRequestContext, requesterId: number, summary: string): Promise<TicketListItem> {
+  const response = await request.get(`${API_URL}/api/tickets?search=${encodeURIComponent(summary)}`, {
+    headers: { "X-Requester-Id": String(requesterId) },
+  });
+  expect(response.ok()).toBeTruthy();
+  const body = await response.json() as { items: TicketListItem[] };
+  const matches = body.items.filter((item) => item.summary === summary);
+  expect(matches).toHaveLength(1);
+  return matches[0];
+}
+
+function pdfFixture() {
+  return Buffer.from("%PDF-1.4\nE2E fixture\n", "utf8");
+}
+
+function pngFixture() {
+  return Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+}
+
+test.describe("Lab 2 requester-to-Ticket workflow", () => {
+  test("creates a Ticket with mixed Attachments and verifies authoritative backend values", async ({ page, request }) => {
+    const requesterId = await enterRequesterWorkspace(page);
+    await openCreateTicket(page);
+
+    const summary = `E2E mixed attachments ${Date.now()}`;
+    await fillValidTicket(page, summary);
+    await page.locator("#attachments").setInputFiles([
+      { name: "e2e-mixed.pdf", mimeType: "application/pdf", buffer: pdfFixture() },
+      { name: "e2e-mixed.png", mimeType: "image/png", buffer: pngFixture() },
+    ]);
+    await expect(page.getByText("e2e-mixed.pdf", { exact: false })).toBeVisible();
+    await expect(page.getByText("e2e-mixed.png", { exact: false })).toBeVisible();
+
+    await page.getByRole("button", { name: "Submit Ticket", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "Ticket created" })).toBeVisible();
+    const ticketNumber = await page.locator(".alert-success strong").textContent();
+    expect(ticketNumber).toMatch(/^TKT-\d{4}-\d{6}$/);
+    await expect(page.getByText("e2e-mixed.pdf: Uploaded", { exact: true })).toBeVisible();
+    await expect(page.getByText("e2e-mixed.png: Uploaded", { exact: true })).toBeVisible();
+
+    const ticket = await findTicket(request, requesterId, summary);
+    expect(ticket.ticketNumber).toBe(ticketNumber);
+    expect(ticket.requestedPriority).toBe("URGENT");
+    expect(ticket.currentStatus).toBe("NEW");
+
+    const detailResponse = await request.get(`${API_URL}/api/tickets/${ticket.id}`, {
+      headers: { "X-Requester-Id": String(requesterId) },
+    });
+    expect(detailResponse.ok()).toBeTruthy();
+    const detail = await detailResponse.json() as { attachments: Array<{ originalName: string; state: string }> };
+    expect(detail.attachments.map((attachment) => attachment.originalName).sort()).toEqual(["e2e-mixed.pdf", "e2e-mixed.png"]);
+    expect(detail.attachments.every((attachment) => attachment.state === "ACTIVE")).toBeTruthy();
+  });
+
+  test("reuses the logical submission after an ambiguous create failure and retries one failed Attachment", async ({ page, request }) => {
+    const requesterId = await enterRequesterWorkspace(page);
+    await openCreateTicket(page);
+
+    const summary = `E2E retry recovery ${Date.now()}`;
+    await fillValidTicket(page, summary);
+    await page.locator("#attachments").setInputFiles([
+      { name: "e2e-retry.pdf", mimeType: "application/pdf", buffer: pdfFixture() },
+      { name: "e2e-retry.png", mimeType: "image/png", buffer: pngFixture() },
+    ]);
+
+    let createCalls = 0;
+    await page.route("**/api/tickets", async (route) => {
+      if (route.request().method() !== "POST") return route.continue();
+      createCalls += 1;
+      const response = await route.fetch();
+      if (createCalls === 1) {
+        return route.fulfill({
+          status: 503,
+          contentType: "application/json",
+          body: JSON.stringify({ error: { code: "CREATE_TICKET_UNAVAILABLE", message: "Unable to create Ticket" } }),
+        });
+      }
+      return route.fulfill({ response });
+    });
+
+    await page.getByRole("button", { name: "Submit Ticket", exact: true }).click();
+    await expect(page.getByRole("alert")).toContainText("Unable to create Ticket");
+    await expect(page.locator("#summary")).toHaveValue(summary);
+    await expect(page.getByText("e2e-retry.pdf", { exact: false })).toBeVisible();
+
+    let attachmentCalls = 0;
+    await page.route("**/api/tickets/*/attachments", async (route) => {
+      if (route.request().method() !== "POST") return route.continue();
+      attachmentCalls += 1;
+      if (attachmentCalls === 1) {
+        return route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: { code: "ATTACHMENT_UPLOAD_FAILED", message: "Simulated Attachment failure." } }),
+        });
+      }
+      return route.continue();
+    });
+
+    await page.getByRole("alert").getByRole("button", { name: "Retry", exact: true }).click();
+    await page.getByRole("button", { name: "Submit Ticket", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "Ticket created" })).toBeVisible();
+    await expect(page.getByText("e2e-retry.pdf: Simulated Attachment failure.", { exact: false })).toBeVisible();
+    await expect(page.getByText("e2e-retry.png: Uploaded", { exact: false })).toBeVisible();
+
+    await page.getByRole("button", { name: "Retry", exact: true }).click();
+    await expect(page.getByText("e2e-retry.pdf: Uploaded", { exact: false })).toBeVisible();
+
+    const ticket = await findTicket(request, requesterId, summary);
+    expect(createCalls).toBe(2);
+    expect(attachmentCalls).toBe(3);
+    const detailResponse = await request.get(`${API_URL}/api/tickets/${ticket.id}`, {
+      headers: { "X-Requester-Id": String(requesterId) },
+    });
+    expect(detailResponse.ok()).toBeTruthy();
+    const detail = await detailResponse.json() as { attachments: Array<{ originalName: string; state: string }> };
+    expect(detail.attachments).toHaveLength(2);
+    expect(detail.attachments.every((attachment) => attachment.state === "ACTIVE")).toBeTruthy();
+  });
+});

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
@@ -967,6 +968,22 @@
       ],
       "engines": {
         "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@popperjs/core": {
@@ -2609,6 +2626,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "bootstrap": "^5.3.3",
@@ -15,6 +16,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from "@playwright/test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const clientDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryDirectory = path.resolve(clientDirectory, "..");
+const serverDirectory = path.join(repositoryDirectory, "server");
+
+export default defineConfig({
+  testDir: path.join(clientDirectory, "e2e"),
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [["line"], ["html", { outputFolder: "playwright-report", open: "never" }]] : "list",
+  use: {
+    baseURL: "http://127.0.0.1:5173",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    ...devices["Desktop Chrome"],
+  },
+  webServer: [
+    {
+      command: "npm run dev -- --host 127.0.0.1",
+      cwd: clientDirectory,
+      url: "http://127.0.0.1:5173",
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+    {
+      command: "npm run dev",
+      cwd: serverDirectory,
+      url: "http://127.0.0.1:3000/api/health",
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        ...process.env,
+        PORT: "3000",
+        DATABASE_URL: process.env.DATABASE_URL ?? "postgresql://toktickit:toktickit@localhost:5432/toktickit?schema=public",
+        ATTACHMENT_STORAGE_DIR: path.join(repositoryDirectory, "e2e", ".tmp", "attachments"),
+      },
+    },
+  ],
+});

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -99,12 +99,12 @@ Database tests use a dedicated test database/schema. Attachment tests use a task
 
 | ID | Requirement / AC | What it tests | Expected result | Test file | Final |
 | --- | --- | --- | --- | --- | --- |
-| E2E-01 | AC-04, AC-06-AC-12 | Select Requester, create Ticket, mixed files, simulated failure | Backend values, one Ticket, documented recovery | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
-| E2E-02 | AC-13-AC-21 | Create as A, list controls, switch to B, direct A detail | A/B isolation and safe rejection | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
-| E2E-03 | AC-22-AC-27 | Add, download, remove, retained metadata, blocked retry | Complete Attachment lifecycle | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
-| E2E-04 | AC-28-AC-29 | Desktop 1440x900, tablet 820x1180, mobile 390x844 | No clipping/overlap/page scroll; usable controls | `e2e/lab-02/responsive-visual.spec.ts` | Planned |
-| E2E-05 | AC-29 | Required screenshots and Human checklist | Artifacts stored and Human-approved | `e2e/lab-02/responsive-visual.spec.ts` | Planned |
-| E2E-06 | AC-30 | Full builds/tests/seed/workflow on final main | All required commands pass, no skips | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
+| E2E-01 | AC-04, AC-06-AC-12 | Select Requester, create Ticket, mixed files, simulated failure | Backend values, one Ticket, documented recovery | `client/e2e/lab-02/requester-ticket-flow.spec.ts` | PASS |
+| E2E-02 | AC-13-AC-21 | Create as A, list controls, switch to B, direct A detail | A/B isolation and safe rejection | `client/e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
+| E2E-03 | AC-22-AC-27 | Add, download, remove, retained metadata, blocked retry | Complete Attachment lifecycle | `client/e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
+| E2E-04 | AC-28-AC-29 | Desktop 1440x900, tablet 820x1180, mobile 390x844 | No clipping/overlap/page scroll; usable controls | `client/e2e/lab-02/responsive-visual.spec.ts` | Planned |
+| E2E-05 | AC-29 | Required screenshots and Human checklist | Artifacts stored and Human-approved | `client/e2e/lab-02/responsive-visual.spec.ts` | Planned |
+| E2E-06 | AC-30 | Full builds/tests/seed/workflow on final main | All required commands pass, no skips | `client/e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
 
 ## 6. Acceptance-Criterion Traceability
 
@@ -176,7 +176,7 @@ Set-Location ..
 
 # Playwright configured through client/
 Set-Location client
-npx playwright test
+npm run e2e
 Set-Location ..
 ```
 
@@ -242,6 +242,12 @@ Focused commands belong in Issue/PR evidence; final evidence must come from comp
 - `npm test` from `client/`: **passed** (9 test files, 54 tests).
 - `npm run build` from `client/`: **passed**.
 - Coverage includes required markers and programmatic labels, read-only/editable distinction, primary/secondary/busy button states, equivalent desktop table/mobile card content, semantic sort state, active navigation `aria-current`, first-invalid focus, loading `aria-busy`/status announcements, text-labelled priority/status/actions, focus-visible styles, and reduced-motion support.
+
+### Feature 18 Evidence
+
+- Playwright E2E suite: **2 tests passed** for E2E-01.
+- `npm run e2e` from `client/`: **passed** (2 tests, Chromium; real Vite client, Express API, PostgreSQL, migrations, seed, and Attachment storage).
+- Coverage includes active Requester selection, real reference-data loading, valid Ticket creation with mixed PDF/PNG Attachments, backend-generated Ticket Number and `NEW` status, simulated ambiguous create response with form retention, idempotent retry without duplicate Ticket, partial Attachment failure, and individual Attachment retry.
 
 ## 10. Known Limitations and Deferred Tests
 

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -245,8 +245,10 @@ Focused commands belong in Issue/PR evidence; final evidence must come from comp
 
 ### Feature 18 Evidence
 
+- Scope is Issue #38 / E2E-01 only; E2E-02 through E2E-06 remain planned for the subsequent ownership, Attachment, responsive, visual-evidence, and final-release Issues.
 - Playwright E2E suite: **2 tests passed** for E2E-01.
 - `npm run e2e` from `client/`: **passed** (2 tests, Chromium; real Vite client, Express API, PostgreSQL, migrations, seed, and Attachment storage).
+- Hosted E2E CI runs the Prisma seed twice before Playwright to verify repeatable reference-data setup.
 - Coverage includes active Requester selection, real reference-data loading, valid Ticket creation with mixed PDF/PNG Attachments, backend-generated Ticket Number and `NEW` status, simulated ambiguous create response with form retention, idempotent retry without duplicate Ticket, partial Attachment failure, and individual Attachment retry.
 
 ## 10. Known Limitations and Deferred Tests


### PR DESCRIPTION
## Summary

Implements Issue #38 / E2E-01 Playwright coverage for the complete Requester-to-Ticket workflow.

This PR is intentionally scoped to Feature 18 E2E-01. Issue #43 (final verification and release) remains a separate follow-up issue covering E2E-02 through E2E-06 and the final lab2-staging to main release.

## Coverage

- Selects an active Development Requester through the real client and API
- Loads Categories and Related Systems from PostgreSQL
- Creates a valid Ticket with mixed PDF and PNG Attachments
- Verifies backend-generated Ticket Number and NEW status
- Simulates an ambiguous create response and verifies form retention
- Retries with the same logical clientRequestId without creating a duplicate Ticket
- Simulates partial Attachment failure and retries the failed file individually
- Verifies final Ticket and Attachment metadata through the real API

## Verification

- Playwright E2E: 2 tests passed
- Client tests: 54 tests passed
- Client build: passed
- PostgreSQL migration and seed completed
- Hosted E2E CI runs the seed twice before Playwright

Closes #38