### PR TITLE
Feature 19: E2E My Tickets ownership and Ticket Detail flow

### DIFF
--- a/client/e2e/lab-02/requester-ticket-flow.spec.ts
+++ b/client/e2e/lab-02/requester-ticket-flow.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+import { randomUUID } from "node:crypto";
 
 const API_URL = process.env.E2E_API_URL ?? "http://127.0.0.1:3000";
 
@@ -10,18 +11,64 @@ type TicketListItem = {
   currentStatus: string;
 };
 
-async function enterRequesterWorkspace(page: Page): Promise<number> {
+type ReferenceItem = { id: number; name: string };
+type Requester = ReferenceItem;
+
+async function enterRequesterWorkspace(page: Page, requestedRequesterId?: number): Promise<number> {
   await page.goto("/");
   const requesterSelect = page.locator("#requester-select");
   await expect(requesterSelect).toBeVisible();
   const activeRequesterOption = requesterSelect.locator('option:not([value=""])').first();
   await expect(activeRequesterOption).toHaveCount(1);
-  const requesterId = Number(await activeRequesterOption.getAttribute("value"));
+  const requesterId = requestedRequesterId ?? Number(await activeRequesterOption.getAttribute("value"));
   expect(Number.isSafeInteger(requesterId)).toBeTruthy();
   await requesterSelect.selectOption(String(requesterId));
   await page.getByRole("button", { name: "Continue", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Welcome to TokTickIT" })).toBeVisible();
   return requesterId;
+}
+
+async function getActiveRequesters(request: APIRequestContext): Promise<Requester[]> {
+  const response = await request.get(`${API_URL}/api/development-requesters`);
+  expect(response.ok()).toBeTruthy();
+  return await response.json() as Requester[];
+}
+
+async function getReferenceData(request: APIRequestContext): Promise<{ category: ReferenceItem; relatedSystem: ReferenceItem }> {
+  const [categoriesResponse, systemsResponse] = await Promise.all([
+    request.get(`${API_URL}/api/categories`),
+    request.get(`${API_URL}/api/related-systems`),
+  ]);
+  expect(categoriesResponse.ok()).toBeTruthy();
+  expect(systemsResponse.ok()).toBeTruthy();
+  const categories = await categoriesResponse.json() as ReferenceItem[];
+  const relatedSystems = await systemsResponse.json() as ReferenceItem[];
+  expect(categories.length).toBeGreaterThan(0);
+  expect(relatedSystems.length).toBeGreaterThan(0);
+  return { category: categories[0], relatedSystem: relatedSystems[0] };
+}
+
+async function createTicketForRequester(
+  request: APIRequestContext,
+  requesterId: number,
+  summary: string,
+  references: { category: ReferenceItem; relatedSystem: ReferenceItem },
+  requestedPriority: "LOW" | "MEDIUM" | "HIGH" | "URGENT" = "HIGH",
+): Promise<TicketListItem> {
+  const response = await request.post(`${API_URL}/api/tickets`, {
+    headers: { "X-Requester-Id": String(requesterId), "Content-Type": "application/json" },
+    data: {
+      clientRequestId: randomUUID(),
+      categoryId: references.category.id,
+      relatedSystemId: references.relatedSystem.id,
+      summary,
+      requestedPriority,
+      description: "Feature 19 end-to-end ownership verification.",
+    },
+  });
+  expect(response.status()).toBe(201);
+  const body = await response.json() as { ticket: TicketListItem };
+  return body.ticket;
 }
 
 async function openCreateTicket(page: Page) {
@@ -157,5 +204,124 @@ test.describe("Lab 2 requester-to-Ticket workflow", () => {
     const detail = await detailResponse.json() as { attachments: Array<{ originalName: string; state: string }> };
     expect(detail.attachments).toHaveLength(2);
     expect(detail.attachments.every((attachment) => attachment.state === "ACTIVE")).toBeTruthy();
+  });
+
+  test("isolates Requester A and B, exercises My Tickets controls, and preserves the query after owned Detail", async ({ page, request }) => {
+    const requesters = await getActiveRequesters(request);
+    expect(requesters.length).toBeGreaterThanOrEqual(2);
+    const [requesterA, requesterB] = requesters;
+    const references = await getReferenceData(request);
+    const runId = `${Date.now()}-${randomUUID().slice(0, 8)}`;
+    const targetSummary = `Feature 19 A target ${runId}`;
+    const ticketSummaries = [targetSummary, ...Array.from({ length: 10 }, (_, index) => `Feature 19 A pagination ${runId}-${index}`)];
+    const createdTickets = await Promise.all(ticketSummaries.map((summary, index) => createTicketForRequester(
+      request,
+      requesterA.id,
+      summary,
+      references,
+      index === 0 ? "HIGH" : "MEDIUM",
+    )));
+    const bSummary = `Feature 19 B private ${runId}`;
+    await createTicketForRequester(request, requesterB.id, bSummary, references, "HIGH");
+
+    await enterRequesterWorkspace(page, requesterA.id);
+    await page.getByRole("button", { name: "My Tickets", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "My Tickets" })).toBeVisible();
+    await expect(page.locator(".result-count")).toContainText("Tickets");
+    await expect(page.getByText(bSummary, { exact: true })).toHaveCount(0);
+
+    // Verify real pagination, page-size selection, and page reset behavior.
+    await page.locator("#ticket-page-size").selectOption("10");
+    await expect(page.locator(".pagination")).toContainText("Page 1 of");
+    await page.getByRole("navigation", { name: "Ticket pagination" }).getByRole("button", { name: "Next", exact: true }).click();
+    await expect(page.locator(".pagination")).toContainText("Page 2 of");
+    await page.locator("#ticket-page-size").selectOption("20");
+    await expect(page.locator(".pagination")).toContainText("Page 1 of");
+
+    // Apply search, AND filters, sort, and direction through the real API.
+    await page.locator("#ticket-search").fill(targetSummary);
+    await expect(page.locator(".result-count")).toHaveText("Showing 1 of 1 Tickets");
+    await page.locator("#ticket-category").selectOption(String(references.category.id));
+    await page.locator("#ticket-system").selectOption(String(references.relatedSystem.id));
+    await page.locator("#ticket-priority").selectOption("HIGH");
+    await page.locator("#ticket-status").selectOption("NEW");
+    await page.locator("#ticket-sort").selectOption("ticketNumber");
+    await page.locator("#ticket-direction").selectOption("asc");
+    await expect(page.locator(".result-count")).toHaveText("Showing 1 of 1 Tickets");
+    await expect(page.locator(".tickets-table tbody").getByText(targetSummary, { exact: true })).toBeVisible();
+
+    const targetTicket = createdTickets[0];
+    await page.locator(".tickets-table tbody tr").filter({ hasText: targetSummary }).getByRole("button", { name: "View Ticket", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "Ticket Information" })).toBeVisible();
+    await expect(page.getByText(targetSummary, { exact: true })).toHaveCount(1);
+    await expect(page.getByRole("heading", { name: targetTicket.ticketNumber, exact: true })).toBeVisible();
+
+    await page.getByRole("button", { name: "Back to My Tickets", exact: false }).click();
+    await expect(page.getByRole("heading", { name: "My Tickets" })).toBeVisible();
+    await expect(page.locator("#ticket-search")).toHaveValue(targetSummary);
+    await expect(page.locator("#ticket-category")).toHaveValue(String(references.category.id));
+    await expect(page.locator("#ticket-system")).toHaveValue(String(references.relatedSystem.id));
+    await expect(page.locator("#ticket-priority")).toHaveValue("HIGH");
+    await expect(page.locator("#ticket-status")).toHaveValue("NEW");
+    await expect(page.locator("#ticket-sort")).toHaveValue("ticketNumber");
+    await expect(page.locator("#ticket-direction")).toHaveValue("asc");
+    await expect(page.locator("#ticket-page-size")).toHaveValue("20");
+    await expect(page.locator(".tickets-table tbody").getByText(targetSummary, { exact: true })).toBeVisible();
+
+    // Switch the active context through the real selector and prove A's state is gone before B loads.
+    await page.getByRole("button", { name: "Change Requester", exact: true }).click();
+    await expect(page.locator("#requester-select")).toBeVisible();
+    await page.locator("#requester-select").selectOption(String(requesterB.id));
+    await page.getByRole("button", { name: "Continue", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "Welcome to TokTickIT" })).toBeVisible();
+    await page.getByRole("button", { name: "My Tickets", exact: true }).click();
+    await expect(page.locator(".tickets-table tbody").getByText(bSummary, { exact: true })).toBeVisible();
+    await expect(page.getByText(targetSummary, { exact: true })).toHaveCount(0);
+  });
+
+  test("rejects cross-owner and missing Ticket Detail safely", async ({ page, request }) => {
+    const requesters = await getActiveRequesters(request);
+    expect(requesters.length).toBeGreaterThanOrEqual(2);
+    const [requesterA, requesterB] = requesters;
+    const references = await getReferenceData(request);
+    const runId = `${Date.now()}-${randomUUID().slice(0, 8)}`;
+    const aSummary = `Feature 19 A protected ${runId}`;
+    const aTicket = await createTicketForRequester(request, requesterA.id, aSummary, references, "HIGH");
+    const bSummary = `Feature 19 B detail ${runId}`;
+    const bTicket = await createTicketForRequester(request, requesterB.id, bSummary, references, "HIGH");
+
+    const crossOwnerResponse = await request.get(`${API_URL}/api/tickets/${aTicket.id}`, {
+      headers: { "X-Requester-Id": String(requesterB.id) },
+    });
+    expect(crossOwnerResponse.status()).toBe(404);
+    const crossOwnerBody = await crossOwnerResponse.json() as { error: { code: string; message: string } };
+    expect(crossOwnerBody.error.code).toBe("RESOURCE_NOT_FOUND");
+    expect(JSON.stringify(crossOwnerBody)).not.toContain(aSummary);
+    expect(JSON.stringify(crossOwnerBody)).not.toContain(aTicket.ticketNumber);
+
+    const missingResponse = await request.get(`${API_URL}/api/tickets/999999999`, {
+      headers: { "X-Requester-Id": String(requesterB.id) },
+    });
+    expect(missingResponse.status()).toBe(404);
+    const missingBody = await missingResponse.json() as { error: { code: string } };
+    expect(missingBody.error.code).toBe("RESOURCE_NOT_FOUND");
+
+    await enterRequesterWorkspace(page, requesterB.id);
+    await page.getByRole("button", { name: "My Tickets", exact: true }).click();
+    await expect(page.locator(".tickets-table tbody").getByText(bSummary, { exact: true })).toBeVisible();
+    await page.route("**/api/tickets/*", async (route) => {
+      if (route.request().method() === "GET" && route.request().url().endsWith(`/api/tickets/${bTicket.id}`)) {
+        return route.fulfill({
+          status: 404,
+          contentType: "application/json",
+          body: JSON.stringify({ error: { code: "RESOURCE_NOT_FOUND", message: "Ticket not found." } }),
+        });
+      }
+      return route.continue();
+    });
+    await page.locator(".tickets-table tbody tr").filter({ hasText: bSummary }).getByRole("button", { name: "View Ticket", exact: true }).click();
+    await expect(page.getByRole("alert")).toContainText("Ticket not found or unavailable.");
+    await expect(page.getByRole("heading", { name: "Ticket Information" })).toHaveCount(0);
+    await expect(page.getByText(aSummary, { exact: true })).toHaveCount(0);
   });
 });

--- a/client/e2e/lab-02/requester-ticket-flow.spec.ts
+++ b/client/e2e/lab-02/requester-ticket-flow.spec.ts
@@ -238,7 +238,15 @@ test.describe("Lab 2 requester-to-Ticket workflow", () => {
     await page.locator("#ticket-page-size").selectOption("20");
     await expect(page.locator(".pagination")).toContainText("Page 1 of");
 
-    // Apply search, AND filters, sort, and direction through the real API.
+    // Verify ticket-number ordering across multiple rows through the real API.
+    await page.locator("#ticket-search").fill(runId);
+    await expect(page.locator(".result-count")).toHaveText("Showing 11 of 11 Tickets");
+    await page.locator("#ticket-sort").selectOption("ticketNumber");
+    await page.locator("#ticket-direction").selectOption("asc");
+    const ticketNumbers = await page.locator(".tickets-table tbody tr td:first-child strong").allTextContents();
+    expect(ticketNumbers).toEqual([...ticketNumbers].sort());
+
+    // Apply search, AND filters, and retain sort/direction for the owned Detail check.
     await page.locator("#ticket-search").fill(targetSummary);
     await expect(page.locator(".result-count")).toHaveText("Showing 1 of 1 Tickets");
     await page.locator("#ticket-category").selectOption(String(references.category.id));
@@ -311,11 +319,10 @@ test.describe("Lab 2 requester-to-Ticket workflow", () => {
     await expect(page.locator(".tickets-table tbody").getByText(bSummary, { exact: true })).toBeVisible();
     await page.route("**/api/tickets/*", async (route) => {
       if (route.request().method() === "GET" && route.request().url().endsWith(`/api/tickets/${bTicket.id}`)) {
-        return route.fulfill({
-          status: 404,
-          contentType: "application/json",
-          body: JSON.stringify({ error: { code: "RESOURCE_NOT_FOUND", message: "Ticket not found." } }),
-        });
+        // Keep B's browser context/header, but request A's ID from the real backend.
+        const response = await route.fetch({ url: `${API_URL}/api/tickets/${aTicket.id}` });
+        expect(response.status()).toBe(404);
+        return route.fulfill({ response });
       }
       return route.continue();
     });

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -100,7 +100,7 @@ Database tests use a dedicated test database/schema. Attachment tests use a task
 | ID | Requirement / AC | What it tests | Expected result | Test file | Final |
 | --- | --- | --- | --- | --- | --- |
 | E2E-01 | AC-04, AC-06-AC-12 | Select Requester, create Ticket, mixed files, simulated failure | Backend values, one Ticket, documented recovery | `client/e2e/lab-02/requester-ticket-flow.spec.ts` | PASS |
-| E2E-02 | AC-13-AC-21 | Create as A, list controls, switch to B, direct A detail | A/B isolation and safe rejection | `client/e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
+| E2E-02 | AC-13-AC-21 | Create as A, list controls, switch to B, direct A detail | A/B isolation and safe rejection | `client/e2e/lab-02/requester-ticket-flow.spec.ts` | PASS |
 | E2E-03 | AC-22-AC-27 | Add, download, remove, retained metadata, blocked retry | Complete Attachment lifecycle | `client/e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
 | E2E-04 | AC-28-AC-29 | Desktop 1440x900, tablet 820x1180, mobile 390x844 | No clipping/overlap/page scroll; usable controls | `client/e2e/lab-02/responsive-visual.spec.ts` | Planned |
 | E2E-05 | AC-29 | Required screenshots and Human checklist | Artifacts stored and Human-approved | `client/e2e/lab-02/responsive-visual.spec.ts` | Planned |
@@ -250,6 +250,13 @@ Focused commands belong in Issue/PR evidence; final evidence must come from comp
 - `npm run e2e` from `client/`: **passed** (2 tests, Chromium; real Vite client, Express API, PostgreSQL, migrations, seed, and Attachment storage).
 - Hosted E2E CI runs the Prisma seed twice before Playwright to verify repeatable reference-data setup.
 - Coverage includes active Requester selection, real reference-data loading, valid Ticket creation with mixed PDF/PNG Attachments, backend-generated Ticket Number and `NEW` status, simulated ambiguous create response with form retention, idempotent retry without duplicate Ticket, partial Attachment failure, and individual Attachment retry.
+
+### Feature 19 Evidence
+
+- Scope is Issue #39 / E2E-02 only; E2E-03 through E2E-06 remain planned for the subsequent Attachment, responsive, visual-evidence, and final-release Issues.
+- Playwright E2E suite: **4 tests passed** (2 E2E-01 tests from Feature 18 + 2 E2E-02 tests from Feature 19).
+- `npm run e2e` from `client/`: **passed** (4 tests, Chromium; real Vite client, Express API, PostgreSQL, migrations, seed, and Attachment storage).
+- Coverage includes real Requester A/B ownership isolation, active Ticket creation for both contexts, My Tickets search, combined Category/System/Priority/Status filters, Ticket-number sorting and direction, page-size and next-page pagination, owned Ticket Detail rendering, preservation of non-default My Tickets query values after Back, and safe cross-owner/missing Ticket `404` responses without owner data leakage.
 
 ## 10. Known Limitations and Deferred Tests
 


### PR DESCRIPTION
Closes #39

## Summary

เพิ่ม E2E test สำหรับ My Tickets และ Ticket Detail ตาม Lab 2

## Coverage

- ตรวจสอบการแยกข้อมูล Requester A/B
- ทดสอบ Search และ Filters
- ทดสอบ Sorting และ Pagination
- เปิด Ticket Detail ของเจ้าของ
- รักษาค่า Query หลังกลับจาก Detail
- ทดสอบเปลี่ยน Requester A → B
- ทดสอบ non-owner/missing Ticket ได้ 404 อย่างปลอดภัย

## Verification

- Playwright E2E: 4 tests passed
- Client tests: 54 tests passed
- Client build: passed