### PR TITLE
Feature 20: E2E Attachment lifecycle flow

### DIFF
--- a/client/e2e/lab-02/requester-ticket-flow.spec.ts
+++ b/client/e2e/lab-02/requester-ticket-flow.spec.ts
@@ -331,4 +331,108 @@ test.describe("Lab 2 requester-to-Ticket workflow", () => {
     await expect(page.getByRole("heading", { name: "Ticket Information" })).toHaveCount(0);
     await expect(page.getByText(aSummary, { exact: true })).toHaveCount(0);
   });
+
+  test("completes the Attachment lifecycle with real upload, retry, download, removal, and safe access checks", async ({ page, request }) => {
+    const requesters = await getActiveRequesters(request);
+    expect(requesters.length).toBeGreaterThanOrEqual(2);
+    const [requesterA, requesterB] = requesters;
+    const references = await getReferenceData(request);
+    const runId = `${Date.now()}-${randomUUID().slice(0, 8)}`;
+    const summary = `Feature 20 Attachment lifecycle ${runId}`;
+    const ticket = await createTicketForRequester(request, requesterA.id, summary, references, "HIGH");
+    const fileName = `feature-20-${runId}.pdf`;
+    const fileBuffer = pdfFixture();
+
+    await enterRequesterWorkspace(page, requesterA.id);
+    await page.getByRole("button", { name: "My Tickets", exact: true }).click();
+    await page.locator("#ticket-search").fill(summary);
+    await expect(page.locator(".tickets-table tbody").getByText(summary, { exact: true })).toBeVisible();
+    await page.locator(".tickets-table tbody tr").filter({ hasText: summary }).getByRole("button", { name: "View Ticket", exact: true }).click();
+    await expect(page.getByRole("heading", { name: ticket.ticketNumber, exact: true })).toBeVisible();
+
+    let uploadAttempts = 0;
+    await page.route("**/api/tickets/*/attachments", async (route) => {
+      if (route.request().method() !== "POST") return route.continue();
+      uploadAttempts += 1;
+      if (uploadAttempts === 1) {
+        return route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: { code: "ATTACHMENT_UPLOAD_FAILED", message: "Simulated lifecycle upload failure." } }),
+        });
+      }
+      return route.continue();
+    });
+
+    await page.locator("#detail-attachments").setInputFiles({ name: fileName, mimeType: "application/pdf", buffer: fileBuffer });
+    await page.getByRole("button", { name: "Upload", exact: true }).click();
+    await expect(page.getByText("File temporarily unavailable.", { exact: true })).toBeVisible();
+    await page.getByRole("button", { name: "Retry", exact: true }).click();
+    await expect(page.getByText(fileName, { exact: true })).toBeVisible();
+    await expect(page.getByText("Active", { exact: true })).toBeVisible();
+    expect(uploadAttempts).toBe(2);
+
+    const detailResponse = await request.get(`${API_URL}/api/tickets/${ticket.id}`, {
+      headers: { "X-Requester-Id": String(requesterA.id) },
+    });
+    expect(detailResponse.ok()).toBeTruthy();
+    const detail = await detailResponse.json() as { attachments: Array<{ id: number; originalName: string; state: string; removedAt: string | null; removedReason: string | null }> };
+    const uploaded = detail.attachments.find((attachment) => attachment.originalName === fileName);
+    expect(uploaded).toBeDefined();
+    expect(uploaded?.state).toBe("ACTIVE");
+    expect(uploaded?.removedAt).toBeNull();
+    const attachmentId = uploaded!.id;
+
+    const downloadResponse = await request.get(`${API_URL}/api/tickets/${ticket.id}/attachments/${attachmentId}/download`, {
+      headers: { "X-Requester-Id": String(requesterA.id) },
+    });
+    expect(downloadResponse.status()).toBe(200);
+    expect(downloadResponse.headers()["content-type"]).toContain("application/pdf");
+    expect(downloadResponse.headers()["x-content-type-options"]).toBe("nosniff");
+    expect(await downloadResponse.body()).toEqual(fileBuffer);
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Download", exact: true }).click();
+    expect((await downloadPromise).suggestedFilename()).toBe(fileName);
+
+    const removalReason = "Feature 20 lifecycle cleanup";
+    await page.getByRole("button", { name: "Remove", exact: true }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.getByLabel("Reason").fill(removalReason);
+    await page.getByRole("button", { name: "Confirm removal", exact: true }).click();
+    await expect(page.getByText(`Removed · ${removalReason}`, { exact: true })).toBeVisible();
+    await expect(page.getByText("Removed at", { exact: false })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Download", exact: true })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Remove", exact: true })).toHaveCount(0);
+
+    const removedDetailResponse = await request.get(`${API_URL}/api/tickets/${ticket.id}`, {
+      headers: { "X-Requester-Id": String(requesterA.id) },
+    });
+    const removedDetail = await removedDetailResponse.json() as { attachments: Array<{ id: number; state: string; removedAt: string | null; removedReason: string | null }> };
+    const removed = removedDetail.attachments.find((attachment) => attachment.id === attachmentId);
+    expect(removed?.state).toBe("REMOVED");
+    expect(removed?.removedAt).not.toBeNull();
+    expect(removed?.removedReason).toBe(removalReason);
+
+    const removedDownload = await request.get(`${API_URL}/api/tickets/${ticket.id}/attachments/${attachmentId}/download`, {
+      headers: { "X-Requester-Id": String(requesterA.id) },
+    });
+    expect(removedDownload.status()).toBe(404);
+    const removedDownloadBody = await removedDownload.text();
+    expect(removedDownloadBody).not.toContain(fileName);
+    const removedAgain = await request.delete(`${API_URL}/api/tickets/${ticket.id}/attachments/${attachmentId}`, {
+      headers: { "X-Requester-Id": String(requesterA.id), "Content-Type": "application/json" },
+      data: { reason: removalReason },
+    });
+    expect(removedAgain.status()).toBe(404);
+
+    const unauthorizedDownload = await request.get(`${API_URL}/api/tickets/${ticket.id}/attachments/${attachmentId}/download`, {
+      headers: { "X-Requester-Id": String(requesterB.id) },
+    });
+    expect(unauthorizedDownload.status()).toBe(404);
+    const unauthorizedRemove = await request.delete(`${API_URL}/api/tickets/${ticket.id}/attachments/${attachmentId}`, {
+      headers: { "X-Requester-Id": String(requesterB.id), "Content-Type": "application/json" },
+      data: { reason: removalReason },
+    });
+    expect(unauthorizedRemove.status()).toBe(404);
+  });
 });

--- a/client/e2e/lab-02/requester-ticket-flow.spec.ts
+++ b/client/e2e/lab-02/requester-ticket-flow.spec.ts
@@ -394,7 +394,27 @@ test.describe("Lab 2 requester-to-Ticket workflow", () => {
     await page.getByRole("button", { name: "Download", exact: true }).click();
     expect((await downloadPromise).suggestedFilename()).toBe(fileName);
 
+    // Non-owner access must be rejected while the Attachment is still ACTIVE.
+    const unauthorizedDownload = await request.get(`${API_URL}/api/tickets/${ticket.id}/attachments/${attachmentId}/download`, {
+      headers: { "X-Requester-Id": String(requesterB.id) },
+    });
+    expect(unauthorizedDownload.status()).toBe(404);
+    expect(await unauthorizedDownload.text()).not.toContain(fileName);
     const removalReason = "Feature 20 lifecycle cleanup";
+    const unauthorizedRemove = await request.delete(`${API_URL}/api/tickets/${ticket.id}/attachments/${attachmentId}`, {
+      headers: { "X-Requester-Id": String(requesterB.id), "Content-Type": "application/json" },
+      data: { reason: removalReason },
+    });
+    expect(unauthorizedRemove.status()).toBe(404);
+    const afterUnauthorizedResponse = await request.get(`${API_URL}/api/tickets/${ticket.id}`, {
+      headers: { "X-Requester-Id": String(requesterA.id) },
+    });
+    const afterUnauthorized = await afterUnauthorizedResponse.json() as { attachments: Array<{ id: number; state: string; removedAt: string | null; removedReason: string | null }> };
+    const stillActive = afterUnauthorized.attachments.find((attachment) => attachment.id === attachmentId);
+    expect(stillActive?.state).toBe("ACTIVE");
+    expect(stillActive?.removedAt).toBeNull();
+    expect(stillActive?.removedReason).toBeNull();
+
     await page.getByRole("button", { name: "Remove", exact: true }).click();
     await expect(page.getByRole("dialog")).toBeVisible();
     await page.getByLabel("Reason").fill(removalReason);
@@ -424,15 +444,5 @@ test.describe("Lab 2 requester-to-Ticket workflow", () => {
       data: { reason: removalReason },
     });
     expect(removedAgain.status()).toBe(404);
-
-    const unauthorizedDownload = await request.get(`${API_URL}/api/tickets/${ticket.id}/attachments/${attachmentId}/download`, {
-      headers: { "X-Requester-Id": String(requesterB.id) },
-    });
-    expect(unauthorizedDownload.status()).toBe(404);
-    const unauthorizedRemove = await request.delete(`${API_URL}/api/tickets/${ticket.id}/attachments/${attachmentId}`, {
-      headers: { "X-Requester-Id": String(requesterB.id), "Content-Type": "application/json" },
-      data: { reason: removalReason },
-    });
-    expect(unauthorizedRemove.status()).toBe(404);
   });
 });

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -101,7 +101,7 @@ Database tests use a dedicated test database/schema. Attachment tests use a task
 | --- | --- | --- | --- | --- | --- |
 | E2E-01 | AC-04, AC-06-AC-12 | Select Requester, create Ticket, mixed files, simulated failure | Backend values, one Ticket, documented recovery | `client/e2e/lab-02/requester-ticket-flow.spec.ts` | PASS |
 | E2E-02 | AC-13-AC-21 | Create as A, list controls, switch to B, direct A detail | A/B isolation and safe rejection | `client/e2e/lab-02/requester-ticket-flow.spec.ts` | PASS |
-| E2E-03 | AC-22-AC-27 | Add, download, remove, retained metadata, blocked retry | Complete Attachment lifecycle | `client/e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
+| E2E-03 | AC-22-AC-27 | Add, download, remove, retained metadata, blocked retry | Complete Attachment lifecycle | `client/e2e/lab-02/requester-ticket-flow.spec.ts` | PASS |
 | E2E-04 | AC-28-AC-29 | Desktop 1440x900, tablet 820x1180, mobile 390x844 | No clipping/overlap/page scroll; usable controls | `client/e2e/lab-02/responsive-visual.spec.ts` | Planned |
 | E2E-05 | AC-29 | Required screenshots and Human checklist | Artifacts stored and Human-approved | `client/e2e/lab-02/responsive-visual.spec.ts` | Planned |
 | E2E-06 | AC-30 | Full builds/tests/seed/workflow on final main | All required commands pass, no skips | `client/e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
@@ -257,6 +257,13 @@ Focused commands belong in Issue/PR evidence; final evidence must come from comp
 - Playwright E2E suite: **4 tests passed** (2 E2E-01 tests from Feature 18 + 2 E2E-02 tests from Feature 19).
 - `npm run e2e` from `client/`: **passed** (4 tests, Chromium; real Vite client, Express API, PostgreSQL, migrations, seed, and Attachment storage).
 - Coverage includes real Requester A/B ownership isolation, active Ticket creation for both contexts, My Tickets search, combined Category/System/Priority/Status filters, Ticket-number sorting and direction, page-size and next-page pagination, owned Ticket Detail rendering, preservation of non-default My Tickets query values after Back, and safe cross-owner/missing Ticket `404` responses without owner data leakage.
+
+### Feature 20 Evidence
+
+- Scope is Issue #40 / E2E-03 only; E2E-04 through E2E-06 remain planned for responsive, visual-evidence, and final-release verification.
+- Playwright E2E suite: **5 tests passed** (2 E2E-01 tests, 2 E2E-02 tests, and 1 E2E-03 test).
+- `npm run e2e` from `client/`: **passed** (5 tests, Chromium; real Vite client, Express API, PostgreSQL, migrations, seed, and isolated Attachment storage).
+- Coverage includes valid PDF upload, simulated failed upload with individual Retry, active metadata verification, real byte/MIME/`nosniff` download, valid removal reason, retained removed metadata/timestamp/reason, suppression of removed actions, safe 404 for removed download/re-removal, and unauthorized download/removal rejection.
 
 ## 10. Known Limitations and Deferred Tests
 


### PR DESCRIPTION
Closes #40

## Summary

เพิ่ม E2E coverage สำหรับ Attachment lifecycle ตาม Lab 2

## Coverage

- Upload valid Attachment
- Retry failed upload
- Verify active metadata
- Download Attachment จริง
- Remove Attachment พร้อมเหตุผล
- Verify removed timestamp และ reason
- ป้องกันการ Download/Remove Attachment ที่ถูกลบแล้ว
- ตรวจสอบ unauthorized Attachment access

## Verification

- Playwright E2E: 5 tests passed
- Client tests: 54 tests passed
- Client build: passed